### PR TITLE
Adjust streaming backpressure and support Python 3.11

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -81,6 +81,8 @@ Each phase is iterative, testable, and builds on v1.
 * Tests: flow stops mid-run when canceled, no stray tasks.
 * Subflows also canceled.
 
+_Status:_ Cancel API and runtime plumbing implemented with unit coverage; follow-up work will flesh out subflow propagation and richer metrics once Phase 2 expands.
+
 ---
 
 ## Phase 3 — Deadlines & Budgets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "penguiflow"
 version = "1.0.3"
 description = "Async agent orchestration primitives."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 authors = [
     {name = "PenguiFlow Team"},
@@ -38,7 +38,7 @@ managed = true
 
 [tool.ruff]
 line-length = 88
-target-version = "py312"
+target-version = "py311"
 extend-exclude = ["ooflow.py"]
 
 [tool.ruff.lint]
@@ -49,7 +49,7 @@ ignore = []
 known-first-party = ["penguiflow"]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.11"
 plugins = []
 files = ["penguiflow"]
 disallow_untyped_defs = false

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,0 +1,88 @@
+import asyncio
+from collections import Counter
+
+import pytest
+
+from penguiflow import Headers, Message, Node, NodePolicy, create
+
+
+@pytest.mark.asyncio
+async def test_cancel_trace_stops_inflight_run_without_affecting_others() -> None:
+    release = asyncio.Event()
+    slow_started = asyncio.Event()
+    cancelled_flag = asyncio.Event()
+    cancel_started = asyncio.Event()
+    cancel_finished = asyncio.Event()
+    processed: list[str] = []
+    cancel_events: Counter[str] = Counter()
+
+    async def slow(message: Message, _ctx) -> Message:
+        if message.payload == "cancel-me":
+            slow_started.set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancelled_flag.set()
+                raise
+        return message
+
+    async def sink(message: Message, _ctx) -> str:
+        processed.append(str(message.payload))
+        return str(message.payload)
+
+    slow_node = Node(slow, name="slow", policy=NodePolicy(validate="none"))
+    sink_node = Node(sink, name="sink", policy=NodePolicy(validate="none"))
+
+    flow = create(slow_node.to(sink_node))
+
+    async def recorder(event: str, _payload: dict[str, object]) -> None:
+        if event == "trace_cancel_start":
+            cancel_started.set()
+        if event == "trace_cancel_finish":
+            cancel_finished.set()
+        if event.startswith("trace_cancel"):
+            cancel_events[event] += 1
+
+    flow.add_middleware(recorder)
+    flow.run()
+
+    headers = Headers(tenant="demo")
+    cancel_msg = Message(payload="cancel-me", headers=headers)
+    other_msg = Message(payload="other", headers=headers)
+
+    await flow.emit(cancel_msg)
+    await slow_started.wait()
+    await flow.emit(other_msg)
+
+    assert await flow.cancel(cancel_msg.trace_id) is True
+
+    await cancel_started.wait()
+    await cancelled_flag.wait()
+
+    result = await flow.fetch()
+    assert result == "other"
+
+    await cancel_finished.wait()
+
+    assert processed == ["other"]
+    assert cancel_events == Counter(
+        {"trace_cancel_start": 1, "trace_cancel_finish": 1}
+    )
+
+    assert await flow.cancel(cancel_msg.trace_id) is False
+
+    await flow.stop()
+
+
+@pytest.mark.asyncio
+async def test_cancel_unknown_trace_returns_false() -> None:
+    async def passthrough(message: Message, _ctx) -> Message:
+        return message
+
+    node = Node(passthrough, name="pass", policy=NodePolicy(validate="none"))
+    flow = create(node.to())
+    flow.run()
+
+    assert await flow.cancel("missing") is False
+
+    await flow.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
## Summary
- relax the project’s Python floor to 3.11 and align ruff/mypy configs with the new baseline
- allow `Context` to be instantiated without a runtime for tests while enforcing runtime presence when emitting
- add per-trace capacity tracking so streaming chunks respect queue backpressure and ensure cancelled invocations bubble up as `TraceCancelled`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d80e6a71288322b693e7fea6cfc7e9