### PR TITLE
Propagate cancellations into subflows

### DIFF
--- a/examples/playbook_retrieval/README.md
+++ b/examples/playbook_retrieval/README.md
@@ -1,17 +1,19 @@
 # Playbook Retrieval
 
-Shows how to launch a subflow ("playbook") from a controller node using `call_playbook`.
+Shows how to launch a subflow ("playbook") from a controller node using
+`Context.call_playbook`, which automatically propagates cancellations and headers.
 The playbook runs a three-step pipeline — retrieve, rerank, compress — and returns the
 final summary to the parent controller.
 
 ## What happens
 
 1. The controller wraps the incoming message payload into a small dict (`{"query": ...}`)
-   and calls `call_playbook(build_retrieval_playbook, message)`.
+   and calls `ctx.call_playbook(build_retrieval_playbook, message)`.
 2. `build_retrieval_playbook` constructs a standalone `PenguiFlow` with nodes for
    retrieval, reranking, and compression.
-3. `call_playbook` propagates the parent message's headers/trace ID, waits for the first
-   result emitted to the playbook's Rookery, and stops the subflow.
+3. `call_playbook` propagates the parent message's headers/trace ID, mirrors
+   cancellation signals, waits for the first result emitted to the playbook's
+   Rookery, and stops the subflow.
 4. The controller replaces its payload with the returned summary and emits it downstream.
 
 ## Run it

--- a/examples/playbook_retrieval/flow.py
+++ b/examples/playbook_retrieval/flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from penguiflow import Headers, Message, Node, NodePolicy, call_playbook, create
+from penguiflow import Headers, Message, Node, NodePolicy, create
 
 
 def build_retrieval_playbook() -> tuple[Any, Any]:
@@ -36,7 +36,7 @@ def build_retrieval_playbook() -> tuple[Any, Any]:
 
 async def controller(msg: Message, ctx) -> Message:
     request = msg.model_copy(update={"payload": {"query": msg.payload}})
-    summary = await call_playbook(build_retrieval_playbook, request)
+    summary = await ctx.call_playbook(build_retrieval_playbook, request)
     return msg.model_copy(update={"payload": summary})
 
 

--- a/examples/trace_cancel/README.md
+++ b/examples/trace_cancel/README.md
@@ -1,0 +1,24 @@
+# Trace Cancellation with Subflows
+
+Demonstrates cancelling a single trace while it is executing a nested playbook.
+The controller uses `Context.call_playbook` so the subflow receives the same
+cancellation signal, drops in-flight messages, and emits richer metrics.
+
+## Run it
+
+```bash
+uv run python examples/trace_cancel/flow.py
+```
+
+Expected output (timestamps omitted):
+
+```
+subflow: started for trace <id>
+subflow: received cancellation for trace <id>
+trace_cancel_start ... pending=1 inflight=1
+trace_cancel_finish ... pending=0 inflight=0
+safe result: safe
+```
+
+The middleware prints the cancellation metrics payload so you can inspect
+`trace_pending`, `trace_inflight`, and queue depth readings.

--- a/examples/trace_cancel/flow.py
+++ b/examples/trace_cancel/flow.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from penguiflow import Headers, Message, Node, NodePolicy, create
+
+_started = asyncio.Event()
+
+
+def build_cancel_playbook() -> tuple[Any, Any]:
+    async def sub_worker(message: Message, _ctx) -> Message:
+        print(f"subflow: started for trace {message.trace_id}")
+        _started.set()
+        try:
+            await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            print(f"subflow: received cancellation for trace {message.trace_id}")
+            raise
+        return message
+
+    node = Node(sub_worker, name="sub", policy=NodePolicy(validate="none"))
+    return create(node.to()), None
+
+
+async def controller(message: Message, ctx) -> Message:
+    await ctx.call_playbook(build_cancel_playbook, message)
+    return message
+
+
+async def sink(message: Message, _ctx) -> str:
+    return str(message.payload)
+
+
+async def _metrics_printer(event: str, payload: dict[str, object]) -> None:
+    if event.startswith("trace_cancel"):
+        pending = payload["trace_pending"]
+        inflight = payload["trace_inflight"]
+        q_in = payload["q_depth_in"]
+        q_out = payload["q_depth_out"]
+        print(
+            f"{event} pending={pending} inflight={inflight} "
+            f"q_in={q_in} q_out={q_out}"
+        )
+
+
+async def main() -> None:
+    controller_node = Node(
+        controller,
+        name="controller",
+        policy=NodePolicy(validate="none"),
+    )
+    sink_node = Node(
+        sink,
+        name="sink",
+        policy=NodePolicy(validate="none"),
+    )
+
+    flow = create(controller_node.to(sink_node))
+    flow.add_middleware(_metrics_printer)
+    flow.run()
+
+    cancel_msg = Message(payload="cancel-me", headers=Headers(tenant="demo"))
+    safe_msg = Message(payload="safe", headers=Headers(tenant="demo"))
+
+    await flow.emit(cancel_msg)
+    await _started.wait()
+    await flow.cancel(cancel_msg.trace_id)
+
+    await flow.emit(safe_msg)
+    safe_result = await flow.fetch()
+    print(f"safe result: {safe_result}")
+
+    await flow.stop()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    asyncio.run(main())

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -35,9 +35,10 @@ contributors understand how the pieces fit together.
 * **Controller loops**: when a node emits a `Message` whose payload is a `WM`, the runtime
   increments hop counters, enforces budgets, and re-enqueues the message back to the
   controller. Returning a `FinalAnswer` short-circuits to Rookery.
-* **Playbooks**: `call_playbook` accepts a factory that returns a `(PenguiFlow, registry)`
-  pair, runs it, emits the parent message (preserving headers + trace ID), and returns the
-  first payload produced by the subflow.
+* **Playbooks**: `Context.call_playbook` accepts a factory that returns a `(PenguiFlow,
+  registry)` pair, runs it, emits the parent message (preserving headers + trace ID),
+  mirrors cancellation signals to the subflow, and returns the first payload produced by
+  the subflow.
 
 ## Validation & typing
 
@@ -57,10 +58,11 @@ Each helper is a regular node and can be combined with hand-authored nodes seaml
 
 ## Middleware & logging
 
-`_emit_event` emits structured dictionaries with fields:
-`{ts, event, node_name, node_id, trace_id, latency_ms, q_depth_in, attempt, ...}`. Any
-middleware added via `flow.add_middleware` receives these events and can fan them out to
-logging frameworks, observability tools, or metrics backends.
+`_emit_event` emits structured dictionaries with fields such as
+`{ts, event, node_name, node_id, trace_id, latency_ms, q_depth_in, q_depth_out, outgoing,
+trace_pending, trace_inflight, ...}`. Any middleware added via `flow.add_middleware`
+receives these events and can fan them out to logging frameworks, observability tools, or
+metrics backends.
 
 ## Testing & examples
 


### PR DESCRIPTION
## Summary
- enrich `Context` with runtime accessors, queue depth telemetry, and a helper that routes subflow launches through the host runtime
- extend cancellation metrics to report queue depth, per-trace pending counts, and inflight invocations while mirroring cancellation events into nested playbooks
- add regression tests and a runnable example demonstrating trace cancellation propagation alongside updated documentation

## Testing
- `uv run ruff check penguiflow tests examples`
- `uv run mypy penguiflow`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d821d4cab48322863a49d62db45801