### PR TITLE
Add runtime deadline guardrails and token budget enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It provides:
 * **Dynamic loops** (controller nodes)
 * **Runtime playbooks** (callable subflows with shared metadata)
 * **Per-trace cancellation** (`PenguiFlow.cancel` with `TraceCancelled` surfacing in nodes)
-* **Deadlines & budgets** (`Message.deadline_s`, `WM.budget_hops`, and optional `WM.budget_tokens` guardrails)
+* **Deadlines & budgets** (`Message.deadline_s`, `WM.budget_hops`, and `WM.budget_tokens` guardrails that you can leave unset/`None`)
 
 Built on pure `asyncio` (no threads), PenguiFlow is small, predictable, and repo-agnostic.
 Product repos only define **their models + node functions** — the core stays dependency-light.
@@ -197,6 +197,7 @@ Phase 3 adds wall-clock and logical guardrails so long-running traces shut down 
 
 * Set `Message.deadline_s` to cap wall-clock time for a trace. The runtime now checks deadlines before invoking each node and short-circuits to Rookery with `FinalAnswer("Deadline exceeded")` when the clock has expired.
 * Controllers can increment `WM.tokens_used` alongside `WM.hops`. When `WM.budget_tokens` is configured, PenguiFlow automatically emits `FinalAnswer("Token budget exhausted")` once the total meets or exceeds the budget, similar to the existing hop budget.
+* Leave `deadline_s` unset or configure `WM.budget_hops=None` / `WM.budget_tokens=None` to keep the behaviour unbounded—guardrails are entirely opt-in.
 * Tests in `tests/test_budgets.py` cover both deadline short-circuiting and token budget enforcement, complementing the hop and deadline checks exercised in `tests/test_controller.py`.
 * Example: `examples/controller_multihop/` demonstrates configuring deadlines, hop limits, and token budgets together in a looping controller.
 

--- a/examples/controller_multihop/README.md
+++ b/examples/controller_multihop/README.md
@@ -17,6 +17,8 @@ models shipped with PenguiFlow.
 The runtime increments `WM.hops`, tracks `WM.tokens_used`, and checks the configured
 `budget_hops`, `budget_tokens`, and `Message.deadline_s`. If any limit is exceeded,
 PenguiFlow returns a `FinalAnswer` with an exhaustion message instead of looping forever.
+Leave any of these fields unset/`None` when you want the loop to run without that
+particular guardrail.
 
 ## Run it
 
@@ -31,4 +33,5 @@ Token budget exhausted
 ```
 
 Try changing `budget_hops`, `budget_tokens`, or adding simulated latency in the controller
-to see how the runtime enforces deadlines and budgets.
+to see how the runtime enforces deadlines and budgets—or set them to `None` to observe the
+unbounded behaviour.

--- a/examples/controller_multihop/README.md
+++ b/examples/controller_multihop/README.md
@@ -14,9 +14,9 @@ models shipped with PenguiFlow.
 
 ## Guardrails
 
-The runtime increments `WM.hops` and checks both `budget_hops` and `deadline_s`. If either
-limit is exceeded, PenguiFlow returns a `FinalAnswer` with an error message instead of
-looping forever.
+The runtime increments `WM.hops`, tracks `WM.tokens_used`, and checks the configured
+`budget_hops`, `budget_tokens`, and `Message.deadline_s`. If any limit is exceeded,
+PenguiFlow returns a `FinalAnswer` with an exhaustion message instead of looping forever.
 
 ## Run it
 
@@ -27,8 +27,8 @@ uv run python examples/controller_multihop/flow.py
 On completion you should see something like:
 
 ```
-answer after 3 hops
+Token budget exhausted
 ```
 
-Try changing `budget_hops` or adding simulated latency in the controller to see how the
-runtime enforces budgets and deadlines.
+Try changing `budget_hops`, `budget_tokens`, or adding simulated latency in the controller
+to see how the runtime enforces deadlines and budgets.

--- a/llm.txt
+++ b/llm.txt
@@ -10,7 +10,7 @@ Runtime overview
 - Per-trace cancellation: `await flow.cancel(trace_id)` requests cancellation and raises `TraceCancelled` inside the affected
   nodes/subflows. Cancellation is idempotent and only impacts the matching trace.
 - `Message.deadline_s` guards wall-clock execution; the runtime checks deadlines before invoking nodes and sends
-  `FinalAnswer("Deadline exceeded")` to Rookery when expired.
+  `FinalAnswer("Deadline exceeded")` to Rookery when expired. Leave it unset when no wall-clock limit is needed.
 - Messages travel as Pydantic `Message` objects (payload + headers + trace metadata).
 
 Nodes & policies
@@ -44,6 +44,7 @@ Deadlines & budgets
 - Controller payload `WM` now tracks `tokens_used` and optional `budget_tokens` in addition to `hops`/`budget_hops`.
 - When `WM.tokens_used >= WM.budget_tokens` (if configured) or the hop budget is reached, PenguiFlow emits a terminal
   `FinalAnswer` (`"Token budget exhausted"` / `"Hop budget exhausted"`) to Rookery without another controller invocation.
+- Set `WM.budget_hops=None` / `WM.budget_tokens=None` to disable those guardrails for an unbounded loop.
 
 Patterns (`penguiflow.patterns`)
 --------------------------------
@@ -71,8 +72,8 @@ Controller loop models (`penguiflow.types`)
 - `Thought`: optional planning artifact (`steps`, `rationale`, `done`).
 - `PlanStep`: enumerated tool/action descriptions.
 - `FinalAnswer`: terminal payload (`text`, `citations`).
-- Runtime auto-increments `WM.hops`, enforces hop/token budgets, and checks deadlines before re-enqueueing controller messages;
-  violations automatically become `FinalAnswer` messages with the exhaustion reason.
+- Runtime auto-increments `WM.hops`, enforces hop/token budgets when present, and checks deadlines before re-enqueueing
+  controller messages; violations automatically become `FinalAnswer` messages with the exhaustion reason.
 
 Playbooks
 ---------

--- a/llm.txt
+++ b/llm.txt
@@ -1,5 +1,5 @@
-PenguiFlow quick facts (v1 shipped, v2 Phase 1 streaming in progress)
-====================================================================
+PenguiFlow quick facts (v1 shipped, v2 streaming + cancellation + deadlines/budgets)
+===================================================================================
 
 Runtime overview
 ----------------
@@ -7,6 +7,10 @@ Runtime overview
 - Graph endpoints: `OPEN_SEA` (ingress) and `ROOKERY` (egress); both use `Context` APIs.
 - `PenguiFlow.create(*adjacencies, queue_maxsize=64, allow_cycles=False, middlewares=None)` builds the graph.
 - Call `flow.run(registry=...)` once to start worker tasks, `flow.stop()` to cancel/await them.
+- Per-trace cancellation: `await flow.cancel(trace_id)` requests cancellation and raises `TraceCancelled` inside the affected
+  nodes/subflows. Cancellation is idempotent and only impacts the matching trace.
+- `Message.deadline_s` guards wall-clock execution; the runtime checks deadlines before invoking nodes and sends
+  `FinalAnswer("Deadline exceeded")` to Rookery when expired.
 - Messages travel as Pydantic `Message` objects (payload + headers + trace metadata).
 
 Nodes & policies
@@ -21,7 +25,8 @@ Type safety
 - Register models via `ModelRegistry.register(node_name, InModel, OutModel)`.
 - Pass registry to `flow.run(registry)`; `Node.invoke` validates according to policy.
 - `Message` payload can be any type; `StreamChunk` is a first-class payload for streaming paths.
-- `Headers` include `tenant`, optional `topic`, `priority`, plus auto `trace_id`, `ts`, optional `deadline_s`.
+- `Headers` include `tenant`, optional `topic`, `priority`; `Message` carries `trace_id`, `ts`, and optional `deadline_s` for
+  per-trace wall-clock guardrails.
 - Runtime verifies that any node with validation enabled is registered when `flow.run(registry=...)` is called.
 
 Contexts & helpers
@@ -31,6 +36,14 @@ Contexts & helpers
 - Structured logs emitted per node event: `{ts, event, node_name, node_id, trace_id, latency_ms, q_depth_in, attempt, ...}`.
 - Middleware hook: async callables added via `flow.add_middleware(fn)`; receive the event payload.
 - Visualization helper: `flow_to_mermaid(flow, direction="TD")` produces a Mermaid diagram string of the current graph.
+
+Deadlines & budgets
+-------------------
+- Runtime validates `Message.deadline_s` before any node executes; expired work is skipped and turned into
+  `FinalAnswer("Deadline exceeded")` automatically.
+- Controller payload `WM` now tracks `tokens_used` and optional `budget_tokens` in addition to `hops`/`budget_hops`.
+- When `WM.tokens_used >= WM.budget_tokens` (if configured) or the hop budget is reached, PenguiFlow emits a terminal
+  `FinalAnswer` (`"Token budget exhausted"` / `"Hop budget exhausted"`) to Rookery without another controller invocation.
 
 Patterns (`penguiflow.patterns`)
 --------------------------------
@@ -54,11 +67,12 @@ Streaming
 
 Controller loop models (`penguiflow.types`)
 -------------------------------------------
-- `WM`: working memory (`query`, `facts`, `hops`, `budget_hops`, `confidence`).
+- `WM`: working memory (`query`, `facts`, `hops`, `budget_hops`, `tokens_used`, `budget_tokens`, `confidence`).
 - `Thought`: optional planning artifact (`steps`, `rationale`, `done`).
 - `PlanStep`: enumerated tool/action descriptions.
 - `FinalAnswer`: terminal payload (`text`, `citations`).
-- Runtime auto-increments `WM.hops`, enforces `budget_hops` and `deadline_s`, converts violations to `FinalAnswer` with predefined text.
+- Runtime auto-increments `WM.hops`, enforces hop/token budgets, and checks deadlines before re-enqueueing controller messages;
+  violations automatically become `FinalAnswer` messages with the exhaustion reason.
 
 Playbooks
 ---------

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -36,10 +36,10 @@ contributors understand how the pieces fit together.
   every validating node has a corresponding entry in the registry so configuration issues
   surface immediately.
 * **Controller loops**: when a node emits a `Message` whose payload is a `WM`, the runtime
-  increments hop counters, enforces hop/token budgets (`budget_hops` / `budget_tokens`),
-  checks deadlines, and re-enqueues the message back to the controller. Returning a
-  `FinalAnswer` short-circuits to Rookery or, if guardrails fire, the runtime creates a
-  `FinalAnswer` with the appropriate exhaustion message.
+  increments hop counters, enforces hop/token budgets (`budget_hops` / `budget_tokens`) when
+  they are set, checks deadlines, and re-enqueues the message back to the controller.
+  Returning a `FinalAnswer` short-circuits to Rookery or, if guardrails fire, the runtime
+  creates a `FinalAnswer` with the appropriate exhaustion message.
 * **Playbooks**: `Context.call_playbook` accepts a factory that returns a `(PenguiFlow,
   registry)` pair, runs it, emits the parent message (preserving headers + trace ID),
   mirrors cancellation signals to the subflow, and returns the first payload produced by

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -29,12 +29,17 @@ contributors understand how the pieces fit together.
 * **Reliability envelope**: each message dispatch goes through `_execute_with_reliability`
   which applies validation, timeout, retry with exponential backoff, structured logging,
   and middleware hooks.
+* **Deadline enforcement**: nodes never start executing stale work; `Message.deadline_s`
+  is checked prior to invocation and expired traces are converted to
+  `FinalAnswer("Deadline exceeded")` without running the user coroutine.
 * **Registry guardrails**: when `flow.run(registry=...)` is used, the runtime asserts that
   every validating node has a corresponding entry in the registry so configuration issues
   surface immediately.
 * **Controller loops**: when a node emits a `Message` whose payload is a `WM`, the runtime
-  increments hop counters, enforces budgets, and re-enqueues the message back to the
-  controller. Returning a `FinalAnswer` short-circuits to Rookery.
+  increments hop counters, enforces hop/token budgets (`budget_hops` / `budget_tokens`),
+  checks deadlines, and re-enqueues the message back to the controller. Returning a
+  `FinalAnswer` short-circuits to Rookery or, if guardrails fire, the runtime creates a
+  `FinalAnswer` with the appropriate exhaustion message.
 * **Playbooks**: `Context.call_playbook` accepts a factory that returns a `(PenguiFlow,
   registry)` pair, runs it, emits the parent message (preserving headers + trace ID),
   mirrors cancellation signals to the subflow, and returns the first payload produced by

--- a/penguiflow/core.py
+++ b/penguiflow/core.py
@@ -922,7 +922,10 @@ class PenguiFlow:
                     final_msg = result.model_copy(update={"payload": final})
                     return "rookery", final_msg, None
 
-                if payload.hops + 1 >= payload.budget_hops:
+                if (
+                    payload.budget_hops is not None
+                    and payload.hops + 1 >= payload.budget_hops
+                ):
                     final = FinalAnswer(text=BUDGET_EXCEEDED_TEXT)
                     final_msg = result.model_copy(update={"payload": final})
                     return "rookery", final_msg, None

--- a/penguiflow/types.py
+++ b/penguiflow/types.py
@@ -49,7 +49,7 @@ class WM(BaseModel):
     query: str
     facts: list[Any] = Field(default_factory=list)
     hops: int = 0
-    budget_hops: int = 8
+    budget_hops: int | None = 8
     tokens_used: int = 0
     budget_tokens: int | None = None
     confidence: float = 0.0

--- a/penguiflow/types.py
+++ b/penguiflow/types.py
@@ -50,6 +50,8 @@ class WM(BaseModel):
     facts: list[Any] = Field(default_factory=list)
     hops: int = 0
     budget_hops: int = 8
+    tokens_used: int = 0
+    budget_tokens: int | None = None
     confidence: float = 0.0
 
 

--- a/tests/test_budgets.py
+++ b/tests/test_budgets.py
@@ -1,0 +1,76 @@
+import time
+
+import pytest
+
+from penguiflow import (
+    WM,
+    FinalAnswer,
+    Headers,
+    Message,
+    Node,
+    NodePolicy,
+    create,
+)
+
+
+@pytest.mark.asyncio
+async def test_deadline_prevents_node_execution() -> None:
+    calls = 0
+
+    async def worker(msg: Message, ctx) -> Message:
+        nonlocal calls
+        calls += 1
+        return msg
+
+    node = Node(worker, name="worker", policy=NodePolicy(validate="none"))
+    flow = create(node.to())
+    flow.run()
+
+    expired_message = Message(
+        payload=WM(query="q"),
+        headers=Headers(tenant="acme"),
+        deadline_s=time.time() - 0.1,
+    )
+
+    await flow.emit(expired_message)
+    result = await flow.fetch()
+
+    assert isinstance(result, Message)
+    final = result.payload
+    assert isinstance(final, FinalAnswer)
+    assert final.text == "Deadline exceeded"
+    assert calls == 0
+
+    await flow.stop()
+
+
+@pytest.mark.asyncio
+async def test_controller_enforces_token_budget() -> None:
+    async def controller(msg: Message, ctx) -> Message:
+        wm = msg.payload
+        assert isinstance(wm, WM)
+        updated = wm.model_copy(update={"tokens_used": wm.tokens_used + 5})
+        return msg.model_copy(update={"payload": updated})
+
+    controller_node = Node(
+        controller,
+        name="controller",
+        allow_cycle=True,
+        policy=NodePolicy(validate="none"),
+    )
+
+    flow = create(controller_node.to(controller_node))
+    flow.run()
+
+    wm = WM(query="q", budget_hops=10, budget_tokens=12)
+    message = Message(payload=wm, headers=Headers(tenant="acme"))
+
+    await flow.emit(message)
+    result = await flow.fetch()
+
+    assert isinstance(result, Message)
+    final = result.payload
+    assert isinstance(final, FinalAnswer)
+    assert final.text == "Token budget exhausted"
+
+    await flow.stop()


### PR DESCRIPTION
## Summary
- enforce message deadlines before node execution and add token budget handling in the controller loop, including new runtime events
- extend the WM model plus docs and examples to cover token budgets and deadline guardrails, updating root/library READMEs and llm guidance
- add budget-focused unit tests that cover deadline short-circuiting and token exhaustion scenarios

## Testing
- uv run ruff check .
- uv run mypy penguiflow
- uv run python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d832cf8b688322b790d60284e4eef2