### PR TITLE
Add message metadata propagation support

### DIFF
--- a/examples/metadata_propagation/README.md
+++ b/examples/metadata_propagation/README.md
@@ -1,0 +1,23 @@
+# Metadata propagation demo
+
+This example shows how PenguiFlow's `Message.meta` dictionary lets nodes attach
+and consume auxiliary context (such as retrieval cost or model choices) without
+altering the main payload.
+
+## Running
+
+```bash
+uv run python examples/metadata_propagation/flow.py
+```
+
+## What it does
+
+1. `annotate_cost` records a `retrieval_cost_ms` entry on the incoming message.
+2. `summarize` reads that metadata, adds summarizer details, and updates the
+   message payload with a formatted summary string.
+3. The final node forwards the enriched message to Rookery; the script prints
+   the payload and metadata so you can verify the round-trip.
+
+Metadata travels automatically through the runtime, subflows, and streaming
+helpers, so you can enrich messages with debugging, attribution, or billing
+signals while keeping payloads clean.

--- a/examples/metadata_propagation/flow.py
+++ b/examples/metadata_propagation/flow.py
@@ -1,0 +1,61 @@
+"""Metadata propagation demo for PenguiFlow."""
+
+from __future__ import annotations
+
+import asyncio
+
+from penguiflow import Headers, Message, Node, create
+
+
+async def annotate_cost(message: Message, _ctx) -> Message:
+    """Add retrieval cost metadata without mutating payload."""
+
+    message.meta["retrieval_cost_ms"] = 87
+    return message
+
+
+async def summarize(message: Message, _ctx) -> Message:
+    """Read metadata and add summarizer details."""
+
+    cost = message.meta.get("retrieval_cost_ms", 0)
+    new_meta = dict(message.meta)
+    new_meta["summary_model"] = "penguin-x1"
+    new_meta["summary_tokens"] = 128
+    return message.model_copy(
+        update={
+            "payload": f"Summary(cost={cost}ms): {message.payload}",
+            "meta": new_meta,
+        }
+    )
+
+
+async def sink(message: Message, _ctx) -> Message:
+    """Forward the final message to Rookery."""
+
+    return message
+
+
+async def main() -> None:
+    annotate_node = Node(annotate_cost, name="annotate_cost")
+    summarize_node = Node(summarize, name="summarize")
+    sink_node = Node(sink, name="sink")
+
+    flow = create(
+        annotate_node.to(summarize_node),
+        summarize_node.to(sink_node),
+    )
+    flow.run()
+
+    headers = Headers(tenant="acme", topic="metadata-demo")
+    message = Message(payload="documents about penguins", headers=headers)
+
+    await flow.emit(message)
+    result = await flow.fetch()
+    await flow.stop()
+
+    print("Payload:", result.payload)
+    print("Metadata:", result.meta)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/llm.txt
+++ b/llm.txt
@@ -11,7 +11,7 @@ Runtime overview
   nodes/subflows. Cancellation is idempotent and only impacts the matching trace.
 - `Message.deadline_s` guards wall-clock execution; the runtime checks deadlines before invoking nodes and sends
   `FinalAnswer("Deadline exceeded")` to Rookery when expired. Leave it unset when no wall-clock limit is needed.
-- Messages travel as Pydantic `Message` objects (payload + headers + trace metadata).
+- Messages travel as Pydantic `Message` objects (payload + headers + trace metadata + a mutable `meta` bag).
 
 Nodes & policies
 ----------------
@@ -24,14 +24,17 @@ Type safety
 -----------
 - Register models via `ModelRegistry.register(node_name, InModel, OutModel)`.
 - Pass registry to `flow.run(registry)`; `Node.invoke` validates according to policy.
-- `Message` payload can be any type; `StreamChunk` is a first-class payload for streaming paths.
-- `Headers` include `tenant`, optional `topic`, `priority`; `Message` carries `trace_id`, `ts`, and optional `deadline_s` for
-  per-trace wall-clock guardrails.
+- `Message` payload can be any type; the `.meta` dictionary is for auxiliary context and `StreamChunk` is a first-class payload for
+  streaming paths.
+- `Headers` include `tenant`, optional `topic`, `priority`; `Message` carries `trace_id`, `ts`, optional `deadline_s`, and
+  `meta` for per-trace guardrails plus side-channel metadata.
 - Runtime verifies that any node with validation enabled is registered when `flow.run(registry=...)` is called.
 
 Contexts & helpers
 ------------------
 - Each node gets a `Context` with `.emit()`/`.emit_nowait()` (selective or broadcast), `.emit_chunk()` for streaming replies, and `.fetch()`/`.fetch_any()` for incoming queues. `PenguiFlow.emit_chunk(...)` mirrors the helper for callers outside a node (e.g., SSE responders).
+- Metadata written to `message.meta` flows through retries, controller loops, playbooks, and streaming helpers; `emit_chunk`
+  clones the parent's metadata when wrapping `StreamChunk` payloads.
 - Cycle detection: default topological check; per-node opt-in self cycles (`allow_cycle=True`) or global `allow_cycles=True`.
 - Structured logs emitted per node event: `{ts, event, node_name, node_id, trace_id, latency_ms, q_depth_in, attempt, ...}`.
 - Middleware hook: async callables added via `flow.add_middleware(fn)`; receive the event payload.
@@ -97,6 +100,7 @@ Examples reference map
 - `examples/reliability_middleware/` — timeout/retry/middleware logging.
 - `examples/playbook_retrieval/` — controller invoking a subflow playbook.
 - `examples/streaming_llm/` — mock LLM emitting `StreamChunk`s to an SSE-style sink.
+- `examples/metadata_propagation/` — attaching and consuming `Message.meta` context across nodes.
 - `benchmarks/` — microbenchmarks for throughput, retry/timeout, and controller playbook latency.
 
 Testing & tooling

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -10,7 +10,7 @@ contributors understand how the pieces fit together.
 | --- | --- |
 | `core.py` | Runtime graph builder, execution engine, retries/timeouts, controller loop semantics, and playbook helper. |
 | `node.py` | `Node` wrapper and `NodePolicy` configuration (validation scope, timeout, retry/backoff). |
-| `types.py` | Pydantic models for headers, messages, and controller/state artifacts (`WM`, `Thought`, `FinalAnswer`). |
+| `types.py` | Pydantic models for headers, messages (with `Message.meta` bag), and controller/state artifacts (`WM`, `Thought`, `FinalAnswer`). |
 | `registry.py` | `ModelRegistry` that caches `TypeAdapter`s for per-node validation. |
 | `patterns.py` | Batteries-included helpers: `map_concurrent`, routers, and `join_k` aggregator. |
 | `middlewares.py` | Async middleware hook contract for structured logging/observability sinks. |
@@ -29,6 +29,9 @@ contributors understand how the pieces fit together.
 * **Reliability envelope**: each message dispatch goes through `_execute_with_reliability`
   which applies validation, timeout, retry with exponential backoff, structured logging,
   and middleware hooks.
+* **Metadata propagation**: every `Message` includes a mutable `meta` dictionary. The
+  runtime clones it when emitting streaming chunks, preserving debugging or billing
+  breadcrumbs across retries, controller loops, and playbook subflows.
 * **Deadline enforcement**: nodes never start executing stale work; `Message.deadline_s`
   is checked prior to invocation and expired traces are converted to
   `FinalAnswer("Deadline exceeded")` without running the user coroutine.

--- a/penguiflow/core.py
+++ b/penguiflow/core.py
@@ -190,11 +190,14 @@ class Context:
             meta=meta_dict,
         )
 
+        message_meta = dict(parent.meta)
+
         message = Message(
             payload=chunk,
             headers=parent.headers,
             trace_id=parent.trace_id,
             deadline_s=parent.deadline_s,
+            meta=message_meta,
         )
 
         runtime = self._runtime

--- a/penguiflow/types.py
+++ b/penguiflow/types.py
@@ -21,6 +21,7 @@ class Message(BaseModel):
     trace_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     ts: float = Field(default_factory=time.time)
     deadline_s: float | None = None
+    meta: dict[str, Any] = Field(default_factory=dict)
 
 
 class StreamChunk(BaseModel):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,97 @@
+import pytest
+
+from penguiflow import Headers, Message, Node, create
+from penguiflow.types import StreamChunk
+
+
+def test_message_meta_defaults_isolation() -> None:
+    headers = Headers(tenant="acme")
+    msg1 = Message(payload="one", headers=headers)
+    msg2 = Message(payload="two", headers=headers)
+
+    msg1.meta["cost_ms"] = 42
+
+    assert msg1.meta == {"cost_ms": 42}
+    assert msg2.meta == {}
+
+
+@pytest.mark.asyncio
+async def test_metadata_roundtrip_and_update() -> None:
+    async def annotate(message: Message, _ctx) -> Message:
+        message.meta["retrieval_cost"] = 1.23
+        return message
+
+    async def summarize(message: Message, _ctx) -> Message:
+        assert message.meta["retrieval_cost"] == 1.23
+        new_meta = dict(message.meta)
+        new_meta["summary_model"] = "penguin-1"
+        return message.model_copy(
+            update={
+                "payload": f"summary::{message.payload}",
+                "meta": new_meta,
+            }
+        )
+
+    captured: list[Message] = []
+
+    async def sink(message: Message, _ctx) -> Message:
+        captured.append(message)
+        return message
+
+    annotate_node = Node(annotate, name="annotate")
+    summarize_node = Node(summarize, name="summarize")
+    sink_node = Node(sink, name="sink")
+
+    flow = create(
+        annotate_node.to(summarize_node),
+        summarize_node.to(sink_node),
+    )
+    flow.run()
+
+    headers = Headers(tenant="acme")
+    message = Message(payload="docs", headers=headers)
+    await flow.emit(message)
+
+    result = await flow.fetch()
+    await flow.stop()
+
+    assert isinstance(result, Message)
+    assert result.payload == "summary::docs"
+    assert result.meta == {"retrieval_cost": 1.23, "summary_model": "penguin-1"}
+    assert captured and captured[-1].meta == result.meta
+
+
+@pytest.mark.asyncio
+async def test_emit_chunk_preserves_parent_metadata() -> None:
+    async def producer(message: Message, ctx) -> None:
+        await ctx.emit_chunk(
+            parent=message,
+            text="chunk",
+            done=True,
+            meta={"token": 1},
+        )
+
+    seen: list[Message] = []
+
+    async def sink(message: Message, _ctx) -> Message:
+        seen.append(message)
+        return message
+
+    producer_node = Node(producer, name="producer")
+    sink_node = Node(sink, name="sink")
+
+    flow = create(producer_node.to(sink_node))
+    flow.run()
+
+    headers = Headers(tenant="demo")
+    parent = Message(payload="seed", headers=headers, meta={"request_id": "abc"})
+    await flow.emit(parent)
+
+    result = await flow.fetch()
+    await flow.stop()
+
+    assert isinstance(result, Message)
+    assert isinstance(result.payload, StreamChunk)
+    assert result.meta == {"request_id": "abc"}
+    assert result.payload.meta == {"token": 1}
+    assert seen and seen[-1].meta == {"request_id": "abc"}


### PR DESCRIPTION
## Summary
- add a `meta` dictionary to `Message` and ensure streaming helpers copy it
- cover metadata propagation with dedicated unit tests and a runnable example
- refresh documentation across READMEs and llm.txt to highlight the new capability

## Testing
- uv run ruff check .
- uv run mypy penguiflow
- uv run --extra dev coverage run -m pytest
- uv run --extra dev coverage report -m


------
https://chatgpt.com/codex/tasks/task_e_68d984cd9abc8322b62a4989528a0f04