### PR TITLE
Add FlowEvent observability hooks and MLflow example

### DIFF
--- a/examples/mlflow_metrics/README.md
+++ b/examples/mlflow_metrics/README.md
@@ -1,0 +1,29 @@
+# MLflow Metrics Middleware
+
+Demonstrates how PenguiFlow's phase-5 observability hooks expose structured
+`FlowEvent` objects that can be forwarded to MLflow. The example attaches a
+middleware that records queue depth, retry counts, and latency for each node.
+If MLflow is installed, events are logged to a local tracking directory;
+otherwise the middleware prints the captured metrics to stdout so the flow
+remains runnable without extra dependencies.
+
+## Run it
+
+```bash
+uv run python examples/mlflow_metrics/flow.py
+```
+
+The script spins up a three-node flow, attaches the MLflow middleware, emits a
+single message, and prints the final `FinalAnswer` alongside the total number
+of captured events.
+
+To enable MLflow logging, install the optional dependency and re-run the
+example:
+
+```bash
+uv pip install mlflow
+uv run python examples/mlflow_metrics/flow.py
+```
+
+A local `mlruns/` folder will contain the recorded metrics and tags for each
+PenguiFlow event.

--- a/examples/mlflow_metrics/__init__.py
+++ b/examples/mlflow_metrics/__init__.py
@@ -1,0 +1,1 @@
+"""MLflow observability example."""

--- a/examples/mlflow_metrics/flow.py
+++ b/examples/mlflow_metrics/flow.py
@@ -1,0 +1,120 @@
+"""Demo flow that records node events to MLflow (or stdout fallback)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from penguiflow import (
+    FinalAnswer,
+    Headers,
+    Message,
+    Node,
+    NodePolicy,
+    PenguiFlow,
+    create,
+)
+from penguiflow.metrics import FlowEvent
+
+
+class MlflowMiddleware:
+    """Forward runtime events to MLflow if available, otherwise print them."""
+
+    def __init__(
+        self,
+        *,
+        run_name: str = "penguiflow-demo",
+        tracking_dir: str | None = None,
+    ) -> None:
+        self.run_name = run_name
+        self.events: list[FlowEvent] = []
+        self._warned = False
+        self._tracking_dir = tracking_dir
+        try:  # pragma: no cover - optional dependency
+            import mlflow
+        except ModuleNotFoundError:  # pragma: no cover - optional dependency
+            self._mlflow = None
+        else:  # pragma: no cover - optional dependency
+            self._mlflow = mlflow
+            if tracking_dir is not None:
+                tracking_path = Path(tracking_dir).resolve()
+                tracking_path.mkdir(parents=True, exist_ok=True)
+                mlflow.set_tracking_uri(f"file:{tracking_path}")
+            self._active_run = mlflow.start_run(run_name=run_name)
+
+    async def __call__(self, event: FlowEvent) -> None:
+        self.events.append(event)
+
+        if self._mlflow is None:
+            if not self._warned:
+                print("MLflow not installed; capturing events locally only.")
+                self._warned = True
+            metrics = event.metric_samples()
+            print(
+                f"{event.event_type} | node={event.node_name} | metrics={metrics}"
+            )
+            return
+
+        assert self._mlflow is not None  # for type-checkers
+        self._mlflow.set_tags(event.tag_values())
+        metrics = event.metric_samples()
+        for key, value in metrics.items():
+            self._mlflow.log_metric(key, value, step=int(event.ts * 1000))
+
+    def close(self) -> None:
+        if getattr(self, "_mlflow", None) is not None:
+            self._mlflow.end_run()
+
+
+def build_flow(middleware: MlflowMiddleware) -> tuple[PenguiFlow, Node]:
+    """Assemble the demo flow and attach the provided middleware."""
+
+    async def prepare(message: Message, _ctx) -> Message:
+        meta = dict(message.meta)
+        meta["prepared"] = True
+        cleaned = str(message.payload).strip()
+        return message.model_copy(update={"payload": cleaned, "meta": meta})
+
+    async def score(message: Message, _ctx) -> Message:
+        await asyncio.sleep(0.05)
+        meta = dict(message.meta)
+        meta["score"] = len(str(message.payload))
+        enriched = str(message.payload).upper()
+        return message.model_copy(update={"payload": enriched, "meta": meta})
+
+    async def respond(message: Message, _ctx) -> Message:
+        final = FinalAnswer(text=f"Tracked: {message.payload}", citations=["mlflow"])
+        return message.model_copy(update={"payload": final})
+
+    prepare_node = Node(prepare, name="prepare", policy=NodePolicy(validate="none"))
+    score_node = Node(score, name="score", policy=NodePolicy(validate="none"))
+    respond_node = Node(respond, name="respond", policy=NodePolicy(validate="none"))
+
+    flow = create(prepare_node.to(score_node), score_node.to(respond_node))
+    flow.add_middleware(middleware)
+    return flow, respond_node
+
+
+async def main() -> None:
+    middleware = MlflowMiddleware(tracking_dir=Path(__file__).parent / "mlruns")
+    flow, _ = build_flow(middleware)
+    flow.run()
+
+    headers = Headers(tenant="demo", topic="metrics")
+    message = Message(payload="observe penguiflow", headers=headers)
+
+    await flow.emit(message)
+    result = await flow.fetch()
+    await flow.stop()
+    middleware.close()
+
+    if isinstance(result, Message) and isinstance(result.payload, FinalAnswer):
+        print(f"Final answer: {result.payload.text}")
+    else:
+        print(f"Result: {result}")
+
+    print(f"Captured {len(middleware.events)} events.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/llm.txt
+++ b/llm.txt
@@ -84,10 +84,13 @@ Playbooks
 - Subflow receives the original message (headers + trace id preserved).
 - Returns the first payload emitted to playbook’s Rookery; always stops the subflow (shielded).
 
-Middlewares & observability
----------------------------
-- Middleware signature: `async def middleware(event: str, payload: dict[str, Any]): ...`.
-- Typical events: `node_start`, `node_success`, `node_timeout`, `node_error`, `node_retry`, `node_failed`, `node_cancelled`.
+  Middlewares & observability
+  ---------------------------
+  - Middleware signature: `async def middleware(event: FlowEvent): ...`.
+  - `FlowEvent` exposes `.to_payload()` for structured logging plus `.metric_samples()` /
+    `.tag_values()` helpers for metrics sinks.
+  - Typical `event.event_type` values: `node_start`, `node_success`, `node_timeout`,
+    `node_error`, `node_retry`, `node_failed`, `node_cancelled`.
 
 Examples reference map
 ----------------------
@@ -97,7 +100,8 @@ Examples reference map
 - `examples/fanout_join/` — fan-out to workers + `join_k` aggregation.
 - `examples/map_concurrent/` — map helper inside a node.
 - `examples/controller_multihop/` — controller loop producing `FinalAnswer`.
-- `examples/reliability_middleware/` — timeout/retry/middleware logging.
+  - `examples/reliability_middleware/` — timeout/retry/middleware logging.
+  - `examples/mlflow_metrics/` — MLflow-backed metrics middleware (falls back to stdout).
 - `examples/playbook_retrieval/` — controller invoking a subflow playbook.
 - `examples/streaming_llm/` — mock LLM emitting `StreamChunk`s to an SSE-style sink.
 - `examples/metadata_propagation/` — attaching and consuming `Message.meta` context across nodes.

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -13,7 +13,8 @@ contributors understand how the pieces fit together.
 | `types.py` | Pydantic models for headers, messages (with `Message.meta` bag), and controller/state artifacts (`WM`, `Thought`, `FinalAnswer`). |
 | `registry.py` | `ModelRegistry` that caches `TypeAdapter`s for per-node validation. |
 | `patterns.py` | Batteries-included helpers: `map_concurrent`, routers, and `join_k` aggregator. |
-| `middlewares.py` | Async middleware hook contract for structured logging/observability sinks. |
+| `middlewares.py` | Async middleware hook contract consuming structured `FlowEvent` objects. |
+| `metrics.py` | `FlowEvent` model plus helpers for deriving metrics/tags. |
 | `__init__.py` | Public surface that re-exports the main primitives for consumers. |
 
 ## Key runtime behaviors
@@ -66,11 +67,11 @@ Each helper is a regular node and can be combined with hand-authored nodes seaml
 
 ## Middleware & logging
 
-`_emit_event` emits structured dictionaries with fields such as
-`{ts, event, node_name, node_id, trace_id, latency_ms, q_depth_in, q_depth_out, outgoing,
-trace_pending, trace_inflight, ...}`. Any middleware added via `flow.add_middleware`
-receives these events and can fan them out to logging frameworks, observability tools, or
-metrics backends.
+`_emit_event` now materialises a `FlowEvent` dataclass containing fields such as
+`{ts, event_type, node_name, node_id, trace_id, latency_ms, q_depth_in, q_depth_out,
+outgoing, trace_pending, trace_inflight, ...}`. Middleware added via
+`flow.add_middleware` receives these objects, can inspect `.to_payload()` for logging,
+and `.metric_samples()` / `.tag_values()` for metrics sinks like MLflow.
 
 ## Testing & examples
 

--- a/penguiflow/__init__.py
+++ b/penguiflow/__init__.py
@@ -10,6 +10,7 @@ from .core import (
     call_playbook,
     create,
 )
+from .metrics import FlowEvent
 from .middlewares import Middleware
 from .node import Node, NodePolicy
 from .patterns import join_k, map_concurrent, predicate_router, union_router
@@ -33,6 +34,7 @@ __all__ = [
     "NodePolicy",
     "ModelRegistry",
     "Middleware",
+    "FlowEvent",
     "call_playbook",
     "Headers",
     "Message",

--- a/penguiflow/metrics.py
+++ b/penguiflow/metrics.py
@@ -1,0 +1,105 @@
+"""Observability primitives for PenguiFlow."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class FlowEvent:
+    """Structured runtime event emitted around node execution."""
+
+    event_type: str
+    ts: float
+    node_name: str | None
+    node_id: str | None
+    trace_id: str | None
+    attempt: int
+    latency_ms: float | None
+    queue_depth_in: int
+    queue_depth_out: int
+    outgoing_edges: int
+    queue_maxsize: int
+    trace_pending: int | None
+    trace_inflight: int
+    trace_cancelled: bool
+    extra: Mapping[str, Any] = MappingProxyType({})
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "extra", MappingProxyType(dict(self.extra)))
+
+    @property
+    def queue_depth(self) -> int:
+        """Return the combined depth of incoming and outgoing queues."""
+
+        return self.queue_depth_in + self.queue_depth_out
+
+    def to_payload(self) -> dict[str, Any]:
+        """Render a dictionary payload suitable for structured logging."""
+
+        payload: dict[str, Any] = {
+            "ts": self.ts,
+            "event": self.event_type,
+            "node_name": self.node_name,
+            "node_id": self.node_id,
+            "trace_id": self.trace_id,
+            "latency_ms": self.latency_ms,
+            "q_depth_in": self.queue_depth_in,
+            "q_depth_out": self.queue_depth_out,
+            "q_depth_total": self.queue_depth,
+            "outgoing": self.outgoing_edges,
+            "queue_maxsize": self.queue_maxsize,
+            "attempt": self.attempt,
+            "trace_inflight": self.trace_inflight,
+            "trace_cancelled": self.trace_cancelled,
+        }
+        if self.trace_pending is not None:
+            payload["trace_pending"] = self.trace_pending
+        if self.extra:
+            payload.update(self.extra)
+        return payload
+
+    def metric_samples(self) -> dict[str, float]:
+        """Derive numeric metrics for integrations such as MLflow."""
+
+        metrics: dict[str, float] = {
+            "queue_depth_in": float(self.queue_depth_in),
+            "queue_depth_out": float(self.queue_depth_out),
+            "queue_depth_total": float(self.queue_depth),
+            "attempt": float(self.attempt),
+            "trace_inflight": float(self.trace_inflight),
+            "trace_cancelled": 1.0 if self.trace_cancelled else 0.0,
+        }
+        if self.trace_pending is not None:
+            metrics["trace_pending"] = float(self.trace_pending)
+        if self.latency_ms is not None:
+            metrics["latency_ms"] = self.latency_ms
+        if (latency := self.extra.get("latency_ms")) is not None:
+            # Allow extra payloads to inject a latency override for retries.
+            try:
+                metrics["latency_ms"] = float(latency)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                pass
+        return metrics
+
+    def tag_values(self) -> dict[str, str]:
+        """Return string tags describing the event."""
+
+        tags: dict[str, str] = {"event_type": self.event_type}
+        if self.node_name is not None:
+            tags["node_name"] = self.node_name
+        if self.node_id is not None:
+            tags["node_id"] = self.node_id
+        if self.trace_id is not None:
+            tags["trace_id"] = self.trace_id
+        if self.extra:
+            for key, value in self.extra.items():
+                if isinstance(value, str | int | float | bool):
+                    tags[key] = str(value)
+        return tags
+
+
+__all__ = ["FlowEvent"]

--- a/penguiflow/middlewares.py
+++ b/penguiflow/middlewares.py
@@ -1,17 +1,16 @@
-"""Middleware hooks for PenguiFlow.
-
-Instrumentation arrives in Phase 3.
-"""
+"""Middleware hooks for PenguiFlow."""
 
 from __future__ import annotations
 
 from typing import Protocol
 
+from .metrics import FlowEvent
+
 
 class Middleware(Protocol):
-    """Base middleware signature."""
+    """Base middleware signature receiving :class:`FlowEvent` objects."""
 
-    async def __call__(self, event: str, payload: dict[str, object]) -> None: ...
+    async def __call__(self, event: FlowEvent) -> None: ...
 
 
-__all__ = ["Middleware"]
+__all__ = ["Middleware", "FlowEvent"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import BaseModel
 
 from penguiflow.core import CycleError, PenguiFlow, create
+from penguiflow.metrics import FlowEvent
 from penguiflow.node import Node, NodePolicy
 from penguiflow.registry import ModelRegistry
 
@@ -232,8 +233,8 @@ async def test_middlewares_receive_events() -> None:
     events: list[tuple[str, int]] = []
 
     class Collector:
-        async def __call__(self, event: str, payload: dict[str, object]) -> None:
-            events.append((event, int(payload.get("attempt", -1))))
+        async def __call__(self, event: FlowEvent) -> None:
+            events.append((event.event_type, event.attempt))
 
     async def echo(msg: str, ctx) -> str:
         return msg

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,41 @@
+"""Unit tests for FlowEvent observability helpers."""
+
+from __future__ import annotations
+
+from penguiflow.metrics import FlowEvent
+
+
+def test_flow_event_payload_and_metrics() -> None:
+    event = FlowEvent(
+        event_type="node_success",
+        ts=1700000000.0,
+        node_name="worker",
+        node_id="node-1",
+        trace_id="trace-123",
+        attempt=1,
+        latency_ms=12.5,
+        queue_depth_in=2,
+        queue_depth_out=1,
+        outgoing_edges=3,
+        queue_maxsize=64,
+        trace_pending=5,
+        trace_inflight=1,
+        trace_cancelled=False,
+        extra={"custom_tag": "alpha", "latency_ms": "21.0"},
+    )
+
+    payload = event.to_payload()
+    assert payload["event"] == "node_success"
+    assert payload["q_depth_total"] == 3
+    assert payload["trace_pending"] == 5
+    assert payload["custom_tag"] == "alpha"
+
+    metrics = event.metric_samples()
+    assert metrics["queue_depth_total"] == 3.0
+    assert metrics["latency_ms"] == 21.0
+    assert metrics["trace_pending"] == 5.0
+
+    tags = event.tag_values()
+    assert tags["event_type"] == "node_success"
+    assert tags["node_name"] == "worker"
+    assert tags["custom_tag"] == "alpha"


### PR DESCRIPTION
## Summary
- introduce a FlowEvent dataclass, update the middleware protocol, and wire PenguiFlow core to emit structured events
- add an MLflow metrics example and FlowEvent unit tests while adapting existing middleware/cancel tests to the new API
- refresh README, package docs, and llm.txt to document the observability hooks and the new metrics example

## Testing
- uv run ruff check .
- uv run mypy penguiflow
- uv run pytest --cov=penguiflow --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d991739d9083229efc250df8d83bf9