### PR TITLE
Add DOT visualizer and annotated outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,13 +395,19 @@ flow focused on high-level orchestration logic.
 ### Visualization
 
 Need a quick view of the flow topology? Call `flow_to_mermaid(flow)` to render the graph
-as a Mermaid diagram ready for Markdown or docs tools:
+as a Mermaid diagram ready for Markdown or docs tools, or `flow_to_dot(flow)` for a
+Graphviz-friendly definition. Both outputs annotate controller loops and the synthetic
+OpenSea/Rookery boundaries so you can spot ingress/egress paths at a glance:
 
 ```python
-from penguiflow import flow_to_mermaid
+from penguiflow import flow_to_dot, flow_to_mermaid
 
 print(flow_to_mermaid(flow, direction="LR"))
+print(flow_to_dot(flow, rankdir="LR"))
 ```
+
+See `examples/visualizer/` for a runnable script that exports Markdown and DOT files for
+docs or diagramming pipelines.
 
 ---
 
@@ -481,6 +487,7 @@ pytest -q
 * `examples/trace_cancel/`: per-trace cancellation propagating into a playbook.
 * `examples/streaming_llm/`: mock LLM emitting streaming chunks to an SSE sink.
 * `examples/metadata_propagation/`: attaching and consuming `Message.meta` context.
+* `examples/visualizer/`: exports Mermaid + DOT diagrams with loop/subflow annotations.
 
 ---
 

--- a/examples/visualizer/README.md
+++ b/examples/visualizer/README.md
@@ -1,0 +1,23 @@
+# Flow visualizer example
+
+This example generates Mermaid and Graphviz outputs for a small controller
+loop that routes into a summarizer node.
+
+## Run it
+
+```bash
+uv run python examples/visualizer/flow.py
+```
+
+The script writes two files next to the source:
+
+- `diagram.md` – Mermaid source suitable for documentation or Markdown preview
+- `diagram.dot` – Graphviz DOT definition that can be rendered with `dot -Tpng`
+
+Both outputs highlight:
+
+- the controller loop (self-edge annotated as `loop`)
+- the automatic OpenSea/Rookery boundaries (`ingress` and `egress` edges)
+
+The generated Mermaid block is already wrapped in a fenced code block so it
+can be copy/pasted directly into docs.

--- a/examples/visualizer/diagram.dot
+++ b/examples/visualizer/diagram.dot
@@ -1,0 +1,12 @@
+digraph PenguiFlow {
+    rankdir=LR
+    node [shape=box, style=rounded]
+    controller [label="controller", style="rounded,filled", fillcolor="#fef3c7"]
+    summarize [label="summarize"]
+    Rookery [label="Rookery", shape=oval, style="filled", fillcolor="#e0f2fe"]
+    OpenSea [label="OpenSea", shape=oval, style="filled", fillcolor="#e0f2fe"]
+    controller -> controller [label="loop"]
+    summarize -> Rookery [label="egress"]
+    OpenSea -> controller [label="ingress"]
+    controller -> summarize
+}

--- a/examples/visualizer/diagram.md
+++ b/examples/visualizer/diagram.md
@@ -1,0 +1,16 @@
+```mermaid
+graph LR
+    controller["controller"]
+    summarize["summarize"]
+    Rookery["Rookery"]
+    OpenSea["OpenSea"]
+    classDef controller_loop fill:#fef3c7,stroke:#b45309,stroke-width:1px
+    classDef endpoint fill:#e0f2fe,stroke:#0369a1,stroke-width:1px
+    class controller controller_loop
+    class Rookery endpoint
+    class OpenSea endpoint
+    controller -->|loop| controller
+    summarize -->|egress| Rookery
+    OpenSea -->|ingress| controller
+    controller --> summarize
+```

--- a/examples/visualizer/flow.py
+++ b/examples/visualizer/flow.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from penguiflow import Node, NodePolicy, create, flow_to_dot, flow_to_mermaid
+
+
+async def controller(message: str, ctx) -> str:
+    """Simple controller that loops until it receives STOP."""
+
+    if message == "STOP":
+        return message
+    return message
+
+
+async def summarize(message: str, ctx) -> str:
+    """Pretend to summarize the accumulated working memory."""
+
+    return f"summary:{message}"
+
+
+def build_flow_diagrams() -> None:
+    controller_node = Node(
+        controller,
+        name="controller",
+        allow_cycle=True,
+        policy=NodePolicy(validate="none"),
+    )
+    summarize_node = Node(
+        summarize,
+        name="summarize",
+        policy=NodePolicy(validate="none"),
+    )
+
+    flow = create(controller_node.to(controller_node, summarize_node))
+
+    mermaid = flow_to_mermaid(flow, direction="LR")
+    dot = flow_to_dot(flow, rankdir="LR")
+
+    base = Path(__file__).parent
+    (base / "diagram.md").write_text(f"```mermaid\n{mermaid}\n```\n", encoding="utf-8")
+    (base / "diagram.dot").write_text(f"{dot}\n", encoding="utf-8")
+
+    print("Mermaid diagram written to diagram.md")
+    print("DOT diagram written to diagram.dot")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual example
+    build_flow_diagrams()

--- a/llm.txt
+++ b/llm.txt
@@ -38,7 +38,9 @@ Contexts & helpers
 - Cycle detection: default topological check; per-node opt-in self cycles (`allow_cycle=True`) or global `allow_cycles=True`.
 - Structured logs emitted per node event: `{ts, event, node_name, node_id, trace_id, latency_ms, q_depth_in, attempt, ...}`.
 - Middleware hook: async callables added via `flow.add_middleware(fn)`; receive the event payload.
-- Visualization helper: `flow_to_mermaid(flow, direction="TD")` produces a Mermaid diagram string of the current graph.
+- Visualization helper: `flow_to_mermaid(flow, direction="TD")` produces a Mermaid diagram string of the current graph, and
+  `flow_to_dot(flow, rankdir="TB")` emits Graphviz DOT with the same annotations. Both highlight controller loops and the
+  OpenSea/Rookery ingress/egress boundaries.
 
 Deadlines & budgets
 -------------------
@@ -105,6 +107,7 @@ Examples reference map
 - `examples/playbook_retrieval/` — controller invoking a subflow playbook.
 - `examples/streaming_llm/` — mock LLM emitting `StreamChunk`s to an SSE-style sink.
 - `examples/metadata_propagation/` — attaching and consuming `Message.meta` context across nodes.
+- `examples/visualizer/` — generate Mermaid + DOT diagrams with loop/subflow annotations.
 - `benchmarks/` — microbenchmarks for throughput, retry/timeout, and controller playbook latency.
 
 Testing & tooling

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -15,6 +15,7 @@ contributors understand how the pieces fit together.
 | `patterns.py` | Batteries-included helpers: `map_concurrent`, routers, and `join_k` aggregator. |
 | `middlewares.py` | Async middleware hook contract consuming structured `FlowEvent` objects. |
 | `metrics.py` | `FlowEvent` model plus helpers for deriving metrics/tags. |
+| `viz.py` | Mermaid and DOT exporters with loop/subflow annotations. |
 | `__init__.py` | Public surface that re-exports the main primitives for consumers. |
 
 ## Key runtime behaviors
@@ -64,6 +65,15 @@ contributors understand how the pieces fit together.
 * `join_k` — buffer `k` messages per trace id, then emit a combined batch downstream.
 
 Each helper is a regular node and can be combined with hand-authored nodes seamlessly.
+
+## Visualization helpers
+
+`viz.flow_to_mermaid(flow, direction="TD")` and `viz.flow_to_dot(flow, rankdir="TB")`
+inspect the runtime graph and emit Mermaid or Graphviz definitions. Nodes tagged with
+`allow_cycle=True` (controller loops) are highlighted automatically, and edges touching
+`OPEN_SEA`/`ROOKERY` are annotated as ingress/egress so subflow boundaries stand out in
+diagrams. The `examples/visualizer/` folder contains a runnable script that exports both
+formats for docs.
 
 ## Middleware & logging
 

--- a/penguiflow/__init__.py
+++ b/penguiflow/__init__.py
@@ -22,7 +22,7 @@ from .streaming import (
     stream_flow,
 )
 from .types import WM, FinalAnswer, Headers, Message, PlanStep, StreamChunk, Thought
-from .viz import flow_to_mermaid
+from .viz import flow_to_dot, flow_to_mermaid
 
 __all__ = [
     "__version__",
@@ -52,6 +52,7 @@ __all__ = [
     "stream_flow",
     "emit_stream_events",
     "flow_to_mermaid",
+    "flow_to_dot",
     "create",
 ]
 

--- a/penguiflow/viz.py
+++ b/penguiflow/viz.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .core import Endpoint
@@ -11,7 +12,21 @@ from .node import Node
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from .core import PenguiFlow
 
-__all__ = ["flow_to_mermaid"]
+__all__ = ["flow_to_mermaid", "flow_to_dot"]
+
+
+@dataclass
+class _VisualNode:
+    identifier: str
+    label: str
+    classes: list[str]
+
+
+@dataclass
+class _VisualEdge:
+    source: str
+    target: str
+    label: str | None
 
 
 def flow_to_mermaid(flow: PenguiFlow, *, direction: str = "TD") -> str:
@@ -20,42 +35,131 @@ def flow_to_mermaid(flow: PenguiFlow, *, direction: str = "TD") -> str:
     Parameters
     ----------
     flow:
-        The `PenguiFlow` instance to visualize.
+        The :class:`PenguiFlow` instance to visualize.
     direction:
-        Mermaid graph direction ("TD", "LR", etc.). Defaults to top-down.
+        Mermaid graph direction (``"TD"``, ``"LR"``, etc.). Defaults to top-down.
     """
 
+    nodes, edges = _collect_graph(flow)
+
     lines: list[str] = [f"graph {direction}"]
-    nodes: set[object] = set()
+    class_defs = {
+        "endpoint": "fill:#e0f2fe,stroke:#0369a1,stroke-width:1px",
+        "controller_loop": "fill:#fef3c7,stroke:#b45309,stroke-width:1px",
+    }
 
-    for floe in flow._floes:  # noqa: SLF001 - visualization accesses internals by design
-        if floe.source is not None:
-            nodes.add(floe.source)
-        if floe.target is not None:
-            nodes.add(floe.target)
+    used_definitions: set[str] = set()
 
-    id_lookup: dict[object, str] = {}
+    for node in nodes:
+        label = _escape_label(node.label)
+        lines.append(f"    {node.identifier}[\"{label}\"]")
+        for class_name in node.classes:
+            used_definitions.add(class_name)
+
+    for class_name in sorted(used_definitions):
+        style = class_defs.get(class_name)
+        if style:
+            lines.append(f"    classDef {class_name} {style}")
+
+    for node in nodes:
+        if node.classes:
+            classes = " ".join(node.classes)
+            lines.append(f"    class {node.identifier} {classes}")
+
+    for edge in edges:
+        label = f"|{edge.label}|" if edge.label else ""
+        lines.append(f"    {edge.source} -->{label} {edge.target}")
+
+    return "\n".join(lines)
+
+
+def flow_to_dot(flow: PenguiFlow, *, rankdir: str = "TB") -> str:
+    """Render the flow graph as a Graphviz DOT string.
+
+    Parameters
+    ----------
+    flow:
+        The :class:`PenguiFlow` instance to visualize.
+    rankdir:
+        Graph orientation (``"TB"``, ``"LR"``, etc.). Defaults to top-bottom.
+    """
+
+    nodes, edges = _collect_graph(flow)
+
+    lines: list[str] = ["digraph PenguiFlow {", f"    rankdir={rankdir}"]
+    lines.append("    node [shape=box, style=rounded]")
+
+    for node in nodes:
+        attributes: list[str] = [f'label="{node.label}"']
+        if "endpoint" in node.classes:
+            attributes.append('shape=oval')
+            attributes.append('style="filled"')
+            attributes.append('fillcolor="#e0f2fe"')
+        elif "controller_loop" in node.classes:
+            attributes.append('style="rounded,filled"')
+            attributes.append('fillcolor="#fef3c7"')
+        attr_str = ", ".join(attributes)
+        lines.append(f"    {node.identifier} [{attr_str}]")
+
+    for edge in edges:
+        if edge.label:
+            edge_label = _escape_label(edge.label)
+            lines.append(
+                f"    {edge.source} -> {edge.target} [label=\"{edge_label}\"]"
+            )
+        else:
+            lines.append(f"    {edge.source} -> {edge.target}")
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _collect_graph(flow: PenguiFlow) -> tuple[list[_VisualNode], list[_VisualEdge]]:
+    nodes: dict[object, _VisualNode] = {}
+    edges: list[_VisualEdge] = []
     used_ids: set[str] = set()
+    loop_sources: set[object] = set()
 
-    for entity in nodes:
+    def ensure_node(entity: object) -> _VisualNode:
+        node = nodes.get(entity)
+        if node is not None:
+            return node
         label = _display_label(entity)
-        node_id = _unique_id(label, used_ids)
-        used_ids.add(node_id)
-        id_lookup[entity] = node_id
-        lines.append(f"    {node_id}[\"{label}\"]")
+        identifier = _unique_id(label, used_ids)
+        used_ids.add(identifier)
+        classes: list[str] = []
+        if isinstance(entity, Endpoint):
+            classes.append("endpoint")
+        if isinstance(entity, Node) and entity.allow_cycle:
+            classes.append("controller_loop")
+        node = _VisualNode(identifier=identifier, label=label, classes=classes)
+        nodes[entity] = node
+        return node
 
-    for floe in flow._floes:  # noqa: SLF001
+    for floe in flow._floes:  # noqa: SLF001 - visualization inspects internals
         source = floe.source
         target = floe.target
         if source is None or target is None:
             continue
-        src_id = id_lookup.get(source)
-        tgt_id = id_lookup.get(target)
-        if src_id is None or tgt_id is None:
-            continue
-        lines.append(f"    {src_id} --> {tgt_id}")
+        src_node = ensure_node(source)
+        tgt_node = ensure_node(target)
+        if source is target:
+            loop_sources.add(source)
+            label = "loop"
+        elif isinstance(source, Endpoint):
+            label = "ingress"
+        elif isinstance(target, Endpoint):
+            label = "egress"
+        else:
+            label = None
+        edges.append(_VisualEdge(src_node.identifier, tgt_node.identifier, label))
 
-    return "\n".join(lines)
+    if loop_sources:
+        for entity, node in nodes.items():
+            if entity in loop_sources and "controller_loop" not in node.classes:
+                node.classes.append("controller_loop")
+
+    return list(nodes.values()), edges
 
 
 def _display_label(entity: object) -> str:
@@ -74,3 +178,8 @@ def _unique_id(label: str, used: set[str]) -> str:
         index += 1
         candidate = f"{base}_{index}"
     return candidate
+
+
+def _escape_label(label: str) -> str:
+    return label.replace("\"", "\\\"")
+

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -5,25 +5,39 @@ from __future__ import annotations
 import pytest
 
 from penguiflow import Node, NodePolicy, create
-from penguiflow.viz import flow_to_mermaid
+from penguiflow.viz import flow_to_dot, flow_to_mermaid
 
 
 @pytest.mark.asyncio
-async def test_flow_to_mermaid_renders_edges() -> None:
-    async def fan(msg: str, ctx) -> str:
+async def test_visualizers_annotate_loops_and_boundaries() -> None:
+    async def controller(msg: str, ctx) -> str:
         return msg
 
-    async def sink(msg: str, ctx) -> str:
+    async def worker(msg: str, ctx) -> str:
         return msg
 
-    fan_node = Node(fan, name="fan", policy=NodePolicy(validate="none"))
-    sink_node = Node(sink, name="sink", policy=NodePolicy(validate="none"))
+    controller_node = Node(
+        controller,
+        name="controller",
+        allow_cycle=True,
+        policy=NodePolicy(validate="none"),
+    )
+    worker_node = Node(worker, name="worker", policy=NodePolicy(validate="none"))
 
-    flow = create(fan_node.to(sink_node))
+    flow = create(controller_node.to(controller_node, worker_node))
 
     mermaid = flow_to_mermaid(flow)
+    dot = flow_to_dot(flow)
 
     assert mermaid.startswith("graph TD")
-    assert "fan" in mermaid
-    assert "sink" in mermaid
-    assert "-->" in mermaid
+    assert "controller" in mermaid
+    assert "worker" in mermaid
+    assert "|loop|" in mermaid
+    assert "|ingress|" in mermaid
+    assert "|egress|" in mermaid
+    assert "classDef controller_loop" in mermaid
+
+    assert dot.startswith("digraph PenguiFlow")
+    assert "label=\"loop\"" in dot
+    assert "label=\"ingress\"" in dot
+    assert "label=\"egress\"" in dot


### PR DESCRIPTION
## Summary
- add annotated Mermaid output and a new Graphviz DOT exporter for flow visualizations
- provide a runnable visualizer example with generated Mermaid and DOT artifacts
- expand documentation and tests to cover the new visualizer capabilities

## Testing
- uv run ruff check .
- uv run mypy penguiflow
- uv run pytest --cov=penguiflow --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68d9a85494a483228c37f084cbe418d5