### PR TITLE
Add policy-driven routing support

### DIFF
--- a/examples/routing_policy/README.md
+++ b/examples/routing_policy/README.md
@@ -1,0 +1,23 @@
+# Routing by Policy
+
+This example shows how to drive router decisions using a configuration policy. A
+`DictRoutingPolicy` reads `policy.json` and routes customer requests to either a
+marketing or support queue. Updating the JSON mapping immediately changes the
+behavior without altering the code.
+
+## Run It
+
+```bash
+uv run python examples/routing_policy/flow.py
+```
+
+Sample output:
+
+```
+marketing handled launch campaign
+support handled reset password
+support handled premium issue
+```
+
+The last line shows how the updated mapping rewires the `vip` tenant to the
+support queue at runtime.

--- a/examples/routing_policy/flow.py
+++ b/examples/routing_policy/flow.py
@@ -1,0 +1,89 @@
+"""Demonstrates config-driven routing policies."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from penguiflow import (
+    DictRoutingPolicy,
+    Headers,
+    Message,
+    Node,
+    NodePolicy,
+    PenguiFlow,
+    RoutingRequest,
+    create,
+    predicate_router,
+)
+
+POLICY_PATH = Path(__file__).with_name("policy.json")
+
+
+def tenant_key(request: RoutingRequest) -> str:
+    return request.message.headers.tenant
+
+
+async def marketing(msg: Message, ctx) -> str:
+    await asyncio.sleep(0.01)
+    return f"marketing handled {msg.payload}"
+
+
+async def support(msg: Message, ctx) -> str:
+    await asyncio.sleep(0.01)
+    return f"support handled {msg.payload}"
+
+
+def build_flow() -> tuple[DictRoutingPolicy, PenguiFlow]:
+    policy = DictRoutingPolicy.from_json_file(
+        str(POLICY_PATH),
+        default="support",
+        key_getter=tenant_key,
+    )
+
+    router = predicate_router(
+        "router",
+        lambda msg: ["marketing", "support"],
+        policy=policy,
+    )
+    marketing_node = Node(
+        marketing,
+        name="marketing",
+        policy=NodePolicy(validate="none"),
+    )
+    support_node = Node(
+        support,
+        name="support",
+        policy=NodePolicy(validate="none"),
+    )
+    flow = create(
+        router.to(marketing_node, support_node),
+        marketing_node.to(),
+        support_node.to(),
+    )
+    flow.run()
+    return policy, flow
+
+
+async def main() -> None:
+    policy, flow = build_flow()
+
+    async def emit(payload: str, tenant: str) -> str:
+        message = Message(payload=payload, headers=Headers(tenant=tenant))
+        await flow.emit(message)
+        return await flow.fetch()
+
+    print(await emit("launch campaign", tenant="marketing"))
+    print(await emit("reset password", tenant="support"))
+
+    policy.update_mapping(
+        {"marketing": "marketing", "support": "marketing", "vip": "support"}
+    )
+
+    print(await emit("premium issue", tenant="vip"))
+
+    await flow.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/routing_policy/policy.json
+++ b/examples/routing_policy/policy.json
@@ -1,0 +1,4 @@
+{
+  "marketing": "marketing",
+  "support": "support"
+}

--- a/llm.txt
+++ b/llm.txt
@@ -17,6 +17,10 @@ Nodes & policies
 ----------------
 - Define nodes with `Node(async_fn, name?, policy?, allow_cycle=False)`; async function must accept `(message, ctx)`.
 - `NodePolicy` fields: `validate` (`"both"|"in"|"out"|"none"`), `timeout_s`, `max_retries`, `backoff_base`, `backoff_mult`, `max_backoff`.
+- Routers (`predicate_router` / `union_router`) accept an optional `policy=` implementing
+  the `RoutingPolicy` protocol; PenguiFlow passes a `RoutingRequest` describing the
+  message + candidate successors so policies can override or drop routes without
+  changing the flow topology.
 - Retries wrap exceptions *and* timeouts; backoff is exponential with optional cap.
 - If you do not need the `Context`, name it `_ctx` but keep the argument—the runtime passes it every time.
 
@@ -54,9 +58,11 @@ Deadlines & budgets
 Patterns (`penguiflow.patterns`)
 --------------------------------
 - `map_concurrent(items, worker, max_concurrency=8)` — semaphore-bounded async fan-out helper.
-- `predicate_router(name, predicate)` — route to successors based on payload/headers; predicate may return nodes, names, sequences, or None.
+- `predicate_router(name, predicate, policy=None)` — route to successors based on payload/headers; predicate may return nodes, names, sequences, or None, and the optional `policy` can override or filter the result.
 - `union_router(name, DiscriminatedModel)` — validates discriminated unions and forwards to named successor nodes.
 - `join_k(name, k)` — buffer `k` messages per `trace_id`; emits aggregated payload (list payload or list of messages).
+- `DictRoutingPolicy(mapping, key_getter=None)` — convenience helper that loads mapping-driven policies (JSON/env) and can be
+  hot-swapped via `update_mapping`/`set_default`.
 
 Streaming
 ---------
@@ -107,6 +113,7 @@ Examples reference map
 - `examples/playbook_retrieval/` — controller invoking a subflow playbook.
 - `examples/streaming_llm/` — mock LLM emitting `StreamChunk`s to an SSE-style sink.
 - `examples/metadata_propagation/` — attaching and consuming `Message.meta` context across nodes.
+- `examples/routing_policy/` — config-driven policy overrides for predicate routers.
 - `examples/visualizer/` — generate Mermaid + DOT diagrams with loop/subflow annotations.
 - `benchmarks/` — microbenchmarks for throughput, retry/timeout, and controller playbook latency.
 

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -13,6 +13,7 @@ contributors understand how the pieces fit together.
 | `types.py` | Pydantic models for headers, messages (with `Message.meta` bag), and controller/state artifacts (`WM`, `Thought`, `FinalAnswer`). |
 | `registry.py` | `ModelRegistry` that caches `TypeAdapter`s for per-node validation. |
 | `patterns.py` | Batteries-included helpers: `map_concurrent`, routers, and `join_k` aggregator. |
+| `policies.py` | Policy protocol + helpers (e.g., `DictRoutingPolicy`) for config-driven routing decisions. |
 | `middlewares.py` | Async middleware hook contract consuming structured `FlowEvent` objects. |
 | `metrics.py` | `FlowEvent` model plus helpers for deriving metrics/tags. |
 | `viz.py` | Mermaid and DOT exporters with loop/subflow annotations. |
@@ -60,9 +61,13 @@ contributors understand how the pieces fit together.
 ## Patterns cheat sheet
 
 * `map_concurrent` — run an async worker over a list of inputs with bounded concurrency.
-* `predicate_router` — route to successor nodes based on simple boolean predicates.
-* `union_router` — enforce discriminated unions and send each variant to its matching node.
+* `predicate_router` — route to successor nodes based on simple boolean predicates; set
+  `policy=` to consult runtime routing policies.
+* `union_router` — enforce discriminated unions and send each variant to its matching node
+  (also accepts `policy=` overrides).
 * `join_k` — buffer `k` messages per trace id, then emit a combined batch downstream.
+* `DictRoutingPolicy` — load config-driven overrides (JSON/env) and attach them to router
+  helpers via `policy=`.
 
 Each helper is a regular node and can be combined with hand-authored nodes seamlessly.
 

--- a/penguiflow/__init__.py
+++ b/penguiflow/__init__.py
@@ -14,6 +14,7 @@ from .metrics import FlowEvent
 from .middlewares import Middleware
 from .node import Node, NodePolicy
 from .patterns import join_k, map_concurrent, predicate_router, union_router
+from .policies import DictRoutingPolicy, RoutingPolicy, RoutingRequest
 from .registry import ModelRegistry
 from .streaming import (
     chunk_to_ws_json,
@@ -47,6 +48,9 @@ __all__ = [
     "join_k",
     "predicate_router",
     "union_router",
+    "DictRoutingPolicy",
+    "RoutingPolicy",
+    "RoutingRequest",
     "format_sse_event",
     "chunk_to_ws_json",
     "stream_flow",

--- a/penguiflow/policies.py
+++ b/penguiflow/policies.py
@@ -1,0 +1,149 @@
+"""Policy helpers for dynamic routing decisions."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
+
+from .node import Node
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from .core import Context
+else:  # pragma: no cover - runtime fallback
+    class Context:  # type: ignore[too-many-ancestors]
+        """Placeholder context type for runtime annotations."""
+
+        pass
+
+RoutingDecisionType: TypeAlias = None | Node | str | Sequence[Node | str]
+
+
+@dataclass(slots=True)
+class RoutingRequest:
+    """Information provided to routing policies."""
+
+    message: Any
+    context: Context
+    node: Node
+    proposed: tuple[Node, ...]
+    trace_id: str | None
+
+    @property
+    def node_name(self) -> str:
+        return self.node.name or self.node.node_id
+
+    @property
+    def proposed_names(self) -> tuple[str, ...]:
+        names: list[str] = []
+        for candidate in self.proposed:
+            names.append(candidate.name or candidate.node_id)
+        return tuple(names)
+
+
+class RoutingPolicy(Protocol):
+    """Protocol for routing policies used by router nodes."""
+
+    def select(
+        self, request: RoutingRequest
+    ) -> RoutingDecisionType | Awaitable[RoutingDecisionType]:
+        """Return the desired routing targets for *request*."""
+
+
+PolicyCallable = Callable[
+    [RoutingRequest], RoutingDecisionType | Awaitable[RoutingDecisionType]
+]
+PolicyLike = RoutingPolicy | PolicyCallable
+
+
+async def evaluate_policy(
+    policy: PolicyLike,
+    request: RoutingRequest,
+) -> RoutingDecisionType:
+    """Evaluate *policy* for the given *request* supporting sync/async returns."""
+
+    if hasattr(policy, "select"):
+        selector = cast(RoutingPolicy, policy).select
+        candidate = selector(request)
+    else:
+        candidate = cast(PolicyCallable, policy)(request)
+
+    if inspect.isawaitable(candidate):
+        return await candidate
+    return candidate
+
+
+KeyFn = Callable[[RoutingRequest], str | None]
+
+
+class DictRoutingPolicy:
+    """Routing policy driven by a mapping loaded from config."""
+
+    def __init__(
+        self,
+        mapping: Mapping[str, RoutingDecisionType],
+        *,
+        default: RoutingDecisionType = None,
+        key_getter: KeyFn | None = None,
+    ) -> None:
+        self._mapping: dict[str, RoutingDecisionType] = dict(mapping)
+        self._default = default
+        self._key_getter = key_getter or (lambda request: request.trace_id)
+
+    def select(self, request: RoutingRequest) -> RoutingDecisionType:
+        key = self._key_getter(request)
+        if key is None:
+            return self._default
+        return self._mapping.get(key, self._default)
+
+    def update_mapping(self, mapping: Mapping[str, RoutingDecisionType]) -> None:
+        self._mapping = dict(mapping)
+
+    def set_default(self, decision: RoutingDecisionType) -> None:
+        self._default = decision
+
+    @classmethod
+    def from_json(cls, payload: str, **kwargs: Any) -> DictRoutingPolicy:
+        data = json.loads(payload)
+        if not isinstance(data, Mapping):
+            raise TypeError("JSON payload must decode to a mapping")
+        return cls(data, **kwargs)
+
+    @classmethod
+    def from_json_file(cls, path: str, **kwargs: Any) -> DictRoutingPolicy:
+        with open(path, encoding="utf-8") as fh:
+            return cls.from_json(fh.read(), **kwargs)
+
+    @classmethod
+    def from_env(
+        cls,
+        env_var: str,
+        *,
+        loader: Callable[[str], Mapping[str, RoutingDecisionType]] | None = None,
+        default: RoutingDecisionType = None,
+        key_getter: KeyFn | None = None,
+    ) -> DictRoutingPolicy:
+        raw = os.getenv(env_var)
+        if raw is None:
+            raise KeyError(f"Environment variable '{env_var}' not set")
+        if loader is None:
+            data = json.loads(raw)
+        else:
+            data = loader(raw)
+        if not isinstance(data, Mapping):
+            raise TypeError("Policy loader must return a mapping")
+        return cls(data, default=default, key_getter=key_getter)
+
+
+__all__ = [
+    "DictRoutingPolicy",
+    "PolicyCallable",
+    "PolicyLike",
+    "RoutingDecisionType",
+    "RoutingPolicy",
+    "RoutingRequest",
+    "evaluate_policy",
+]

--- a/tests/test_routing_policy.py
+++ b/tests/test_routing_policy.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import cast
+
+import pytest
+
+from penguiflow import (
+    DictRoutingPolicy,
+    Headers,
+    Message,
+    Node,
+    NodePolicy,
+    RoutingRequest,
+    create,
+    predicate_router,
+)
+from penguiflow.core import Context
+
+
+@pytest.mark.asyncio
+async def test_policy_routes_by_tenant() -> None:
+    async def left(msg: Message, ctx) -> str:
+        return f"left:{msg.payload}"
+
+    async def right(msg: Message, ctx) -> str:
+        return f"right:{msg.payload}"
+
+    def build_flow(policy: DictRoutingPolicy):
+        router = predicate_router(
+            "router",
+            lambda msg: ["left", "right"],
+            policy=policy,
+        )
+        left_node = Node(left, name="left", policy=NodePolicy(validate="none"))
+        right_node = Node(right, name="right", policy=NodePolicy(validate="none"))
+        flow = create(
+            router.to(left_node, right_node),
+            left_node.to(),
+            right_node.to(),
+        )
+        flow.run()
+        return flow
+
+    policy_a = DictRoutingPolicy(
+        {"acme": "left", "umbrella": "right"},
+        default="right",
+        key_getter=lambda request: request.message.headers.tenant,
+    )
+    policy_b = DictRoutingPolicy(
+        {"acme": "right"},
+        default="left",
+        key_getter=lambda request: request.message.headers.tenant,
+    )
+
+    flow_a = build_flow(policy_a)
+    flow_b = build_flow(policy_b)
+
+    headers = Headers(tenant="acme")
+    msg = Message(payload="hello", headers=headers)
+
+    await flow_a.emit(msg)
+    assert await flow_a.fetch() == "left:hello"
+
+    await flow_b.emit(msg)
+    assert await flow_b.fetch() == "right:hello"
+
+    await flow_a.stop()
+    await flow_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_policy_can_drop_message() -> None:
+    async def sink(msg: Message, ctx) -> str:
+        return f"sink:{msg.payload}"
+
+    class DropPolicy:
+        async def select(self, request: RoutingRequest):
+            if request.trace_id == "drop-me":
+                return None
+            return request.proposed
+
+    router = predicate_router("router", lambda msg: ["sink"], policy=DropPolicy())
+    sink_node = Node(sink, name="sink", policy=NodePolicy(validate="none"))
+    flow = create(
+        router.to(sink_node),
+        sink_node.to(),
+    )
+    flow.run()
+
+    headers = Headers(tenant="acme")
+    await flow.emit(Message(payload="keep", headers=headers))
+    assert await flow.fetch() == "sink:keep"
+
+    await flow.emit(
+        Message(payload="gone", headers=headers, trace_id="drop-me")
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(flow.fetch(), timeout=0.05)
+
+    await flow.stop()
+
+
+def test_dict_policy_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def noop(msg: Message, ctx) -> None:  # pragma: no cover - helper
+        return None
+
+    node = Node(noop, name="router", policy=NodePolicy(validate="none"))
+    request = RoutingRequest(
+        message=Message(
+            payload="p",
+            headers=Headers(tenant="acme"),
+            trace_id="special",
+        ),
+        context=cast(Context, object()),
+        node=node,
+        proposed=(node,),
+        trace_id="special",
+    )
+
+    payload = json.dumps({"special": ["router"]})
+    policy = DictRoutingPolicy.from_json(payload)
+    assert policy.select(request) == ["router"]
+
+    monkeypatch.setenv("PF_POLICY", payload)
+    policy_env = DictRoutingPolicy.from_env("PF_POLICY")
+    assert policy_env.select(request) == ["router"]


### PR DESCRIPTION
## Summary
- add a configurable routing policy system with a reusable DictRoutingPolicy helper
- allow predicate_router and union_router to accept optional policies and evaluate overrides
- document and demonstrate policy-driven routing with a new example, tests, and README updates

## Testing
- uv run ruff check
- uv run mypy penguiflow
- uv run --extra dev pytest --cov=penguiflow --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68d9ad69d77483228889c9a9dc75f563