### PR TITLE
Add traceable error surface with FlowError wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It provides:
 * **Deadlines & budgets** (`Message.deadline_s`, `WM.budget_hops`, and `WM.budget_tokens` guardrails that you can leave unset/`None`)
 * **Observability hooks** (`FlowEvent` callbacks for logging, MLflow, or custom metrics sinks)
 * **Policy-driven routing** (optional policies steer routers without breaking existing flows)
+* **Traceable exceptions** (`FlowError` captures node/trace metadata and optionally emits to Rookery)
 
 Built on pure `asyncio` (no threads), PenguiFlow is small, predictable, and repo-agnostic.
 Product repos only define **their models + node functions** — the core stays dependency-light.
@@ -235,11 +236,26 @@ can steer traffic from configuration instead of code changes:
   messages) and the helper constructors, while `examples/routing_policy/` shows how to
   reload a JSON mapping without touching the flow graph.
 
+### Traceable exceptions
+
+Phase 8 introduces a uniform error surface so downstream systems can handle failures
+without scraping logs:
+
+* Terminal node failures now build a `FlowError` that includes the trace id, node name,
+  node id, stable error code, and metadata such as the retry attempt and latency.
+* Setting `emit_errors_to_rookery=True` on `create(...)` surfaces the `FlowError` object
+  directly from `flow.fetch()`, preserving backwards compatibility by keeping the flag
+  opt-in.
+* `tests/test_errors.py` ensures retry exhaustion and timeout paths produce the correct
+  codes and metadata, while `examples/traceable_errors/` shows how to inspect the
+  payload in a real flow.
+
 ## 🧭 Repo Structure
 
 penguiflow/
   __init__.py
   core.py          # runtime orchestrator, retries, controller helpers, playbooks
+  errors.py        # FlowError / FlowErrorCode definitions
   node.py
   types.py
   registry.py

--- a/examples/traceable_errors/README.md
+++ b/examples/traceable_errors/README.md
@@ -1,0 +1,25 @@
+# Traceable errors example
+
+This example demonstrates Phase 8 of the PenguiFlow roadmap: **traceable exceptions**.
+
+Running the script will:
+
+1. Build a single-node flow whose node always raises a `RuntimeError`.
+2. Enable `emit_errors_to_rookery=True` so terminal failures are surfaced as `FlowError`
+   objects instead of timing out at fetch time.
+3. Emit a message and print the resulting error payload. The output includes the
+   trace id, node name, error code, and metadata so you can correlate the failure
+   with metrics or downstream systems.
+
+```bash
+uv run python examples/traceable_errors/flow.py
+```
+
+You should see a log similar to:
+
+```
+flow error captured: NODE_EXCEPTION Node 'flaky' raised RuntimeError: external service unavailable trace= 3f6e3f...
+```
+
+The example intentionally keeps the flow tiny so the focus stays on how `FlowError`
+objects can be inspected programmatically or forwarded to observability tooling.

--- a/examples/traceable_errors/flow.py
+++ b/examples/traceable_errors/flow.py
@@ -1,0 +1,51 @@
+"""Example showcasing FlowError emission to the Rookery."""
+
+from __future__ import annotations
+
+import asyncio
+
+from penguiflow import (
+    FlowError,
+    Headers,
+    Message,
+    Node,
+    NodePolicy,
+    create,
+)
+
+
+async def flaky_node(message: Message, _ctx) -> Message:
+    raise RuntimeError("external service unavailable")
+
+
+async def main() -> None:
+    node = Node(
+        flaky_node,
+        name="flaky",  # keep a readable name for error payloads
+        policy=NodePolicy(validate="none", max_retries=1, timeout_s=0.05),
+    )
+
+    flow = create(node.to(), emit_errors_to_rookery=True)
+    flow.run()
+
+    message = Message(payload="trigger", headers=Headers(tenant="demo"))
+
+    await flow.emit(message)
+    result = await flow.fetch()
+
+    if isinstance(result, FlowError):
+        payload = result.to_payload()
+        print(
+            "flow error captured:",
+            payload["code"],
+            payload.get("message"),
+            "trace=", payload.get("trace_id"),
+        )
+    else:  # pragma: no cover - defensive
+        print("unexpected result:", result)
+
+    await flow.stop()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    asyncio.run(main())

--- a/llm.txt
+++ b/llm.txt
@@ -12,6 +12,9 @@ Runtime overview
 - `Message.deadline_s` guards wall-clock execution; the runtime checks deadlines before invoking nodes and sends
   `FinalAnswer("Deadline exceeded")` to Rookery when expired. Leave it unset when no wall-clock limit is needed.
 - Messages travel as Pydantic `Message` objects (payload + headers + trace metadata + a mutable `meta` bag).
+- Exhausted retries and timeouts can emit a `FlowError` object to Rookery when
+  `create(..., emit_errors_to_rookery=True)` is used, preserving the trace id, node
+  metadata, and stable error code for downstream handling.
 
 Nodes & policies
 ----------------
@@ -115,6 +118,7 @@ Examples reference map
 - `examples/metadata_propagation/` — attaching and consuming `Message.meta` context across nodes.
 - `examples/routing_policy/` — config-driven policy overrides for predicate routers.
 - `examples/visualizer/` — generate Mermaid + DOT diagrams with loop/subflow annotations.
+- `examples/traceable_errors/` — opt-in FlowError emission surfaced from Rookery.
 - `benchmarks/` — microbenchmarks for throughput, retry/timeout, and controller playbook latency.
 
 Testing & tooling

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -9,6 +9,7 @@ contributors understand how the pieces fit together.
 | Module | Purpose |
 | --- | --- |
 | `core.py` | Runtime graph builder, execution engine, retries/timeouts, controller loop semantics, and playbook helper. |
+| `errors.py` | Defines `FlowError` and `FlowErrorCode` used for traceable exceptions. |
 | `node.py` | `Node` wrapper and `NodePolicy` configuration (validation scope, timeout, retry/backoff). |
 | `types.py` | Pydantic models for headers, messages (with `Message.meta` bag), and controller/state artifacts (`WM`, `Thought`, `FinalAnswer`). |
 | `registry.py` | `ModelRegistry` that caches `TypeAdapter`s for per-node validation. |
@@ -32,6 +33,10 @@ contributors understand how the pieces fit together.
 * **Reliability envelope**: each message dispatch goes through `_execute_with_reliability`
   which applies validation, timeout, retry with exponential backoff, structured logging,
   and middleware hooks.
+* **Traceable exceptions**: when retries are exhausted or timeouts fire, the runtime
+  builds a `FlowError` capturing the trace id, node metadata, and failure code. Setting
+  `emit_errors_to_rookery=True` on `penguiflow.core.create` pushes the `FlowError`
+  directly to Rookery so callers can inspect it.
 * **Metadata propagation**: every `Message` includes a mutable `meta` dictionary. The
   runtime clones it when emitting streaming chunks, preserving debugging or billing
   breadcrumbs across retries, controller loops, and playbook subflows.

--- a/penguiflow/__init__.py
+++ b/penguiflow/__init__.py
@@ -10,6 +10,7 @@ from .core import (
     call_playbook,
     create,
 )
+from .errors import FlowError, FlowErrorCode
 from .metrics import FlowEvent
 from .middlewares import Middleware
 from .node import Node, NodePolicy
@@ -36,6 +37,8 @@ __all__ = [
     "ModelRegistry",
     "Middleware",
     "FlowEvent",
+    "FlowError",
+    "FlowErrorCode",
     "call_playbook",
     "Headers",
     "Message",

--- a/penguiflow/errors.py
+++ b/penguiflow/errors.py
@@ -1,0 +1,113 @@
+"""Traceable exception surface for PenguiFlow."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import Enum
+from typing import Any
+
+
+class FlowErrorCode(str, Enum):
+    """Stable error codes surfaced by the runtime."""
+
+    NODE_TIMEOUT = "NODE_TIMEOUT"
+    NODE_EXCEPTION = "NODE_EXCEPTION"
+    TRACE_CANCELLED = "TRACE_CANCELLED"
+    DEADLINE_EXCEEDED = "DEADLINE_EXCEEDED"
+    HOP_BUDGET_EXHAUSTED = "HOP_BUDGET_EXHAUSTED"
+    TOKEN_BUDGET_EXHAUSTED = "TOKEN_BUDGET_EXHAUSTED"
+
+
+class FlowError(Exception):
+    """Wraps runtime failures with trace metadata for downstream handling."""
+
+    __slots__ = (
+        "trace_id",
+        "node_name",
+        "node_id",
+        "code",
+        "message",
+        "original_exc",
+        "metadata",
+        "exception_type",
+    )
+
+    def __init__(
+        self,
+        *,
+        trace_id: str | None,
+        node_name: str | None,
+        code: FlowErrorCode | str,
+        message: str,
+        original_exc: BaseException | None = None,
+        node_id: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.trace_id = trace_id
+        self.node_name = node_name
+        self.node_id = node_id
+        self.code = code.value if isinstance(code, FlowErrorCode) else str(code)
+        self.message = message
+        self.original_exc = original_exc
+        self.metadata = dict(metadata or {})
+        self.exception_type = (
+            type(original_exc).__name__ if original_exc is not None else None
+        )
+
+    def __str__(self) -> str:  # pragma: no cover - debug helper
+        trace = f" trace={self.trace_id}" if self.trace_id else ""
+        node = f" node={self.node_name}" if self.node_name else ""
+        return f"[{self.code}] {self.message}{trace}{node}".strip()
+
+    def unwrap(self) -> BaseException | None:
+        """Return the wrapped exception, if any."""
+
+        return self.original_exc
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serialisable representation of the error."""
+
+        payload: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.trace_id is not None:
+            payload["trace_id"] = self.trace_id
+        if self.node_name is not None:
+            payload["node_name"] = self.node_name
+        if self.node_id is not None:
+            payload["node_id"] = self.node_id
+        if self.exception_type is not None:
+            payload["exception_type"] = self.exception_type
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+    @classmethod
+    def from_exception(
+        cls,
+        *,
+        trace_id: str | None,
+        node_name: str | None,
+        node_id: str | None,
+        exc: BaseException,
+        code: FlowErrorCode,
+        message: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> FlowError:
+        """Build a ``FlowError`` from an underlying exception."""
+
+        error_message = message or str(exc) or exc.__class__.__name__
+        return cls(
+            trace_id=trace_id,
+            node_name=node_name,
+            node_id=node_id,
+            code=code,
+            message=error_message,
+            original_exc=exc,
+            metadata=metadata,
+        )
+
+
+__all__ = ["FlowError", "FlowErrorCode"]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from penguiflow import (
+    FlowError,
+    FlowErrorCode,
+    Headers,
+    Message,
+    Node,
+    NodePolicy,
+    create,
+)
+
+
+def test_flow_error_to_payload_roundtrip() -> None:
+    original = ValueError("boom")
+    err = FlowError.from_exception(
+        trace_id="trace-1",
+        node_name="demo",
+        node_id="node-123",
+        exc=original,
+        code=FlowErrorCode.NODE_EXCEPTION,
+        metadata={"attempt": 2, "latency_ms": 12.5},
+    )
+
+    payload = err.to_payload()
+
+    assert payload["code"] == FlowErrorCode.NODE_EXCEPTION.value
+    assert payload["trace_id"] == "trace-1"
+    assert payload["node_name"] == "demo"
+    assert payload["node_id"] == "node-123"
+    assert payload["metadata"]["attempt"] == 2
+    assert payload["metadata"]["latency_ms"] == 12.5
+    assert err.unwrap() is original
+    assert err.exception_type == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_flow_emits_flow_error_on_final_retry() -> None:
+    attempts = 0
+    shared_exc = RuntimeError("pop")
+
+    async def failing_node(message: str, _ctx) -> str:
+        nonlocal attempts
+        attempts += 1
+        raise shared_exc
+
+    node = Node(
+        failing_node,
+        name="failing",
+        policy=NodePolicy(
+            validate="none",
+            max_retries=1,
+            backoff_base=0.01,
+            backoff_mult=1.0,
+        ),
+    )
+    flow = create(node.to(), emit_errors_to_rookery=True)
+    flow.run()
+
+    msg = Message(payload="payload", headers=Headers(tenant="demo"))
+    await flow.emit(msg)
+
+    result = await asyncio.wait_for(flow.fetch(), timeout=0.5)
+
+    assert isinstance(result, FlowError)
+    assert result.code == FlowErrorCode.NODE_EXCEPTION.value
+    assert result.trace_id == msg.trace_id
+    assert result.node_name == "failing"
+    assert result.unwrap() is shared_exc
+    assert result.metadata["attempt"] == 1
+    assert attempts == 2
+
+    await flow.stop()
+
+
+@pytest.mark.asyncio
+async def test_flow_error_metadata_for_timeouts() -> None:
+    async def sleepy(message: str, _ctx) -> str:
+        await asyncio.sleep(0.05)
+        return message
+
+    node = Node(
+        sleepy,
+        name="sleepy",
+        policy=NodePolicy(validate="none", timeout_s=0.01, max_retries=0),
+    )
+    flow = create(node.to(), emit_errors_to_rookery=True)
+    flow.run()
+
+    msg = Message(payload="payload", headers=Headers(tenant="demo"))
+    await flow.emit(msg)
+
+    result = await asyncio.wait_for(flow.fetch(), timeout=0.5)
+
+    assert isinstance(result, FlowError)
+    assert result.code == FlowErrorCode.NODE_TIMEOUT.value
+    assert result.trace_id == msg.trace_id
+    assert result.node_name == "sleepy"
+    assert result.metadata["timeout_s"] == pytest.approx(0.01, rel=1e-6)
+    assert result.metadata["attempt"] == 0
+
+    await flow.stop()


### PR DESCRIPTION
## Summary
- add FlowError/FlowErrorCode and integrate optional Rookery emission when retries are exhausted or timeouts fire
- cover the new error surface with targeted unit tests and a runnable traceable errors example
- document the traceable exceptions feature across package exports, READMEs, and llm quick facts

## Testing
- uv run ruff check .
- uv run mypy penguiflow
- uv run --extra dev pytest --cov=penguiflow --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68d9b734832483228727dc19258dd114