### PR TITLE
Fix call_playbook cancellation and middleware example

### DIFF
--- a/examples/reliability_middleware/flow.py
+++ b/examples/reliability_middleware/flow.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 
-from penguiflow import Headers, Message, Node, NodePolicy, PenguiFlow, create
+from penguiflow import (
+    FlowEvent,
+    Headers,
+    Message,
+    Node,
+    NodePolicy,
+    PenguiFlow,
+    create,
+)
 
 
 def build_flow() -> PenguiFlow:
@@ -35,10 +42,10 @@ def build_flow() -> PenguiFlow:
 
     flow = create(flaky_node.to())
 
-    async def middleware(event: str, payload: dict[str, Any]) -> None:
-        attempt = payload["attempt"]
-        latency = payload.get("latency_ms")
-        print(f"mw:{event}:attempt={attempt} latency={latency}")
+    async def middleware(event: FlowEvent) -> None:
+        attempt = event.attempt
+        latency = event.latency_ms
+        print(f"mw:{event.event_type}:attempt={attempt} latency={latency}")
 
     flow.add_middleware(middleware)
     return flow


### PR DESCRIPTION
## Summary
- update the reliability middleware example to consume FlowEvent objects
- prevent call_playbook from starting subflows when the parent trace is already cancelled
- add a regression test that verifies pre-cancelled traces raise TraceCancelled and keep the subflow idle

## Testing
- uv run ruff check penguiflow tests examples
- uv run mypy penguiflow
- uv run pytest


------
https://chatgpt.com/codex/tasks/task_e_68dac3fe6ec88322878ad002d31a235f