### PR TITLE
Add state store and message bus distribution hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ It provides:
 * **Observability hooks** (`FlowEvent` callbacks for logging, MLflow, or custom metrics sinks)
 * **Policy-driven routing** (optional policies steer routers without breaking existing flows)
 * **Traceable exceptions** (`FlowError` captures node/trace metadata and optionally emits to Rookery)
+* **Distribution hooks (opt-in)** — plug a `StateStore` to persist trace history and a
+  `MessageBus` to publish floe traffic for remote workers without changing existing flows.
 
 Built on pure `asyncio` (no threads), PenguiFlow is small, predictable, and repo-agnostic.
 Product repos only define **their models + node functions** — the core stays dependency-light.
@@ -126,6 +128,10 @@ out = await flow.fetch()      # fetch from Rookery
 print(out.payload)            # PackOut(...)
 await flow.stop()
 ```
+
+> **Opt-in distribution:** pass `state_store=` and/or `message_bus=` when calling
+> `penguiflow.core.create(...)` to persist trace history and publish floe traffic
+> without changing node logic.
 
 ---
 

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -10,6 +10,8 @@ contributors understand how the pieces fit together.
 | --- | --- |
 | `core.py` | Runtime graph builder, execution engine, retries/timeouts, controller loop semantics, and playbook helper. |
 | `errors.py` | Defines `FlowError` and `FlowErrorCode` used for traceable exceptions. |
+| `state.py` | Protocols for pluggable state stores plus the `StoredEvent`/`RemoteBinding` dataclasses. |
+| `bus.py` | Message bus protocol used to fan out floe traffic to remote workers. |
 | `node.py` | `Node` wrapper and `NodePolicy` configuration (validation scope, timeout, retry/backoff). |
 | `types.py` | Pydantic models for headers, messages (with `Message.meta` bag), and controller/state artifacts (`WM`, `Thought`, `FinalAnswer`). |
 | `registry.py` | `ModelRegistry` that caches `TypeAdapter`s for per-node validation. |
@@ -34,6 +36,11 @@ contributors understand how the pieces fit together.
 * **Reliability envelope**: each message dispatch goes through `_execute_with_reliability`
   which applies validation, timeout, retry with exponential backoff, structured logging,
   and middleware hooks.
+* **Distribution hooks**: when a flow is constructed with a `StateStore` or `MessageBus`
+  adapter, runtime events are persisted as `StoredEvent` records (`PenguiFlow.load_history`
+  exposes the trace timeline) and every floe publish also emits a `BusEnvelope` describing
+  the edge, trace id, headers, and metadata. Failures are logged but never surface to
+  user code so adapters can fail independently of the core engine.
 * **Traceable exceptions**: when retries are exhausted or timeouts fire, the runtime
   builds a `FlowError` capturing the trace id, node metadata, and failure code. Setting
   `emit_errors_to_rookery=True` on `penguiflow.core.create` pushes the `FlowError`

--- a/penguiflow/__init__.py
+++ b/penguiflow/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from . import testkit
+from .bus import BusEnvelope, MessageBus
 from .core import (
     DEFAULT_QUEUE_MAXSIZE,
     Context,
@@ -18,6 +19,7 @@ from .node import Node, NodePolicy
 from .patterns import join_k, map_concurrent, predicate_router, union_router
 from .policies import DictRoutingPolicy, RoutingPolicy, RoutingRequest
 from .registry import ModelRegistry
+from .state import RemoteBinding, StateStore, StoredEvent
 from .streaming import (
     chunk_to_ws_json,
     emit_stream_events,
@@ -40,6 +42,8 @@ __all__ = [
     "FlowEvent",
     "FlowError",
     "FlowErrorCode",
+    "MessageBus",
+    "BusEnvelope",
     "call_playbook",
     "Headers",
     "Message",
@@ -63,6 +67,9 @@ __all__ = [
     "flow_to_dot",
     "create",
     "testkit",
+    "StateStore",
+    "StoredEvent",
+    "RemoteBinding",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.1.0a0"

--- a/penguiflow/bus.py
+++ b/penguiflow/bus.py
@@ -1,0 +1,30 @@
+"""Message bus protocol for distributed PenguiFlow edges."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass(slots=True)
+class BusEnvelope:
+    """Structured payload published to a :class:`MessageBus`."""
+
+    edge: str
+    source: str | None
+    target: str | None
+    trace_id: str | None
+    payload: Any
+    headers: Mapping[str, Any] | None
+    meta: Mapping[str, Any] | None
+
+
+class MessageBus(Protocol):
+    """Protocol for pluggable message bus adapters."""
+
+    async def publish(self, envelope: BusEnvelope) -> None:
+        """Publish an envelope for downstream workers."""
+
+
+__all__ = ["BusEnvelope", "MessageBus"]

--- a/penguiflow/state.py
+++ b/penguiflow/state.py
@@ -1,0 +1,64 @@
+"""State store protocol and helpers for PenguiFlow."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .metrics import FlowEvent
+
+
+@dataclass(slots=True)
+class StoredEvent:
+    """Representation of a runtime event persisted by a state store."""
+
+    trace_id: str | None
+    ts: float
+    kind: str
+    node_name: str | None
+    node_id: str | None
+    payload: Mapping[str, Any]
+
+    @classmethod
+    def from_flow_event(cls, event: FlowEvent) -> StoredEvent:
+        """Create a stored representation from a :class:`FlowEvent`."""
+
+        return cls(
+            trace_id=event.trace_id,
+            ts=event.ts,
+            kind=event.event_type,
+            node_name=event.node_name,
+            node_id=event.node_id,
+            payload=event.to_payload(),
+        )
+
+
+@dataclass(slots=True)
+class RemoteBinding:
+    """Association between a trace and a remote worker/agent."""
+
+    trace_id: str
+    context_id: str
+    task_id: str
+    agent_url: str
+
+
+class StateStore(Protocol):
+    """Protocol for durable state adapters used by PenguiFlow."""
+
+    async def save_event(self, event: StoredEvent) -> None:
+        """Persist a runtime event.
+
+        Implementations may choose any storage backend (Postgres, Redis, etc.).
+        The method must be idempotent since retries can emit duplicate events.
+        """
+
+    async def load_history(self, trace_id: str) -> Sequence[StoredEvent]:
+        """Return the ordered history for a trace id."""
+
+    async def save_remote_binding(self, binding: RemoteBinding) -> None:
+        """Persist the mapping between a trace and an external worker."""
+
+
+__all__ = ["StateStore", "StoredEvent", "RemoteBinding"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "penguiflow"
-version = "2.0.0"
+version = "2.1.0a0"
 description = "Async agent orchestration primitives."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/distribution_hooks/README.md
+++ b/tests/distribution_hooks/README.md
@@ -1,0 +1,13 @@
+# Distribution hook tests
+
+This folder documents the coverage goals for `tests/test_distribution_hooks.py`.
+The suite verifies the first phase of PenguiFlow's distributed architecture:
+
+* `StateStore` integration persists every runtime `FlowEvent` and exposes
+  `PenguiFlow.load_history()`.
+* Failures while persisting state are logged but do not crash the flow.
+* `MessageBus` envelopes are published for both `emit` and `emit_nowait`
+  pathways so remote workers can subscribe to edges.
+* Publish failures are surfaced via structured log events instead of raising.
+
+Each scenario runs an actual flow to exercise the async runtime end-to-end.

--- a/tests/test_distribution_hooks.py
+++ b/tests/test_distribution_hooks.py
@@ -1,0 +1,140 @@
+"""Tests for the distribution hooks (state store + message bus)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from penguiflow import Headers, Message, Node, create
+from penguiflow.bus import BusEnvelope, MessageBus
+from penguiflow.state import RemoteBinding, StateStore, StoredEvent
+
+
+async def _echo(message: Message, ctx: Any) -> Message:
+    return message
+
+
+echo_node = Node(_echo, name="echo")
+
+
+class RecordingStateStore(StateStore):
+    def __init__(self) -> None:
+        self.events: list[StoredEvent] = []
+        self.bindings: list[RemoteBinding] = []
+
+    async def save_event(self, event: StoredEvent) -> None:
+        self.events.append(event)
+
+    async def load_history(self, trace_id: str) -> list[StoredEvent]:
+        return [event for event in self.events if event.trace_id == trace_id]
+
+    async def save_remote_binding(self, binding: RemoteBinding) -> None:
+        self.bindings.append(binding)
+
+
+class FailingStateStore(RecordingStateStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self._failed = False
+
+    async def save_event(self, event: StoredEvent) -> None:
+        if not self._failed:
+            self._failed = True
+            raise RuntimeError("boom")
+        await super().save_event(event)
+
+
+class RecordingBus(MessageBus):
+    def __init__(self) -> None:
+        self.envelopes: list[BusEnvelope] = []
+
+    async def publish(self, envelope: BusEnvelope) -> None:
+        self.envelopes.append(envelope)
+
+
+class FailingBus(RecordingBus):
+    def __init__(self) -> None:
+        super().__init__()
+        self._failed = False
+
+    async def publish(self, envelope: BusEnvelope) -> None:
+        if not self._failed:
+            self._failed = True
+            raise RuntimeError("bus-down")
+        await super().publish(envelope)
+
+
+@pytest.mark.asyncio
+async def test_state_store_receives_events_and_history() -> None:
+    store = RecordingStateStore()
+    flow = create(echo_node.to(), state_store=store)
+    flow.run()
+    try:
+        message = Message(payload={"ok": True}, headers=Headers(tenant="acme"))
+        await flow.emit(message)
+        result = await flow.fetch()
+        assert isinstance(result, Message)
+        assert result.payload == {"ok": True}
+
+        history = await flow.load_history(message.trace_id)
+        assert history
+        assert history[0].trace_id == message.trace_id
+    finally:
+        await flow.stop()
+
+
+@pytest.mark.asyncio
+async def test_state_store_failure_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    store = FailingStateStore()
+    flow = create(echo_node.to(), state_store=store)
+    flow.run()
+    caplog.set_level(logging.ERROR, logger="penguiflow.core")
+    try:
+        message = Message(payload={"boom": 1}, headers=Headers(tenant="acme"))
+        await flow.emit(message)
+        await flow.fetch()
+    finally:
+        await flow.stop()
+    assert any("state_store_save_failed" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_message_bus_records_envelopes() -> None:
+    bus = RecordingBus()
+    flow = create(echo_node.to(), message_bus=bus)
+    flow.run()
+    message = Message(payload={"hello": "world"}, headers=Headers(tenant="acme"))
+    other = Message(payload={"mode": "nowait"}, headers=Headers(tenant="acme"))
+    try:
+        await flow.emit(message)
+        await flow.fetch()
+
+        flow.emit_nowait(other)
+        await flow.fetch()
+    finally:
+        await flow.stop()
+
+    assert bus.envelopes
+    trace_ids = {envelope.trace_id for envelope in bus.envelopes}
+    assert message.trace_id in trace_ids
+    assert other.trace_id in trace_ids
+    assert any(envelope.target == "Rookery" for envelope in bus.envelopes)
+
+
+@pytest.mark.asyncio
+async def test_message_bus_failure_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    bus = FailingBus()
+    flow = create(echo_node.to(), message_bus=bus)
+    flow.run()
+    caplog.set_level(logging.ERROR, logger="penguiflow.core")
+    message = Message(payload={"warn": True}, headers=Headers(tenant="acme"))
+    try:
+        flow.emit_nowait(message)
+        await flow.fetch()
+    finally:
+        await flow.stop()
+    assert any(
+        "message_bus_publish_failed" in record.message for record in caplog.records
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -188,7 +188,7 @@ wheels = [
 
 [[package]]
 name = "penguiflow"
-version = "2.0.0"
+version = "2.1.0a0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add core distribution protocols (`state.py`, `bus.py`) and thread them through `PenguiFlow` via opt-in `state_store`/`message_bus` parameters, background publishing, and persisted event history
- expose the new hooks across the public surface, bump the package to 2.1.0a0, and document usage in the root README, package README, and manual
- add an end-to-end test suite for the adapters (with accompanying README) covering success and failure paths for both the state store and message bus

## Testing
- uv run ruff check penguiflow tests
- uv run mypy penguiflow
- uv run --with pytest --with pytest-asyncio --with pytest-cov pytest --cov=penguiflow --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68db108acc30832281a00fb063b11f36