### PR TITLE
Fix remote cancellation cleanup and ensure tests finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ It provides:
 * **Traceable exceptions** (`FlowError` captures node/trace metadata and optionally emits to Rookery)
 * **Distribution hooks (opt-in)** — plug a `StateStore` to persist trace history and a
   `MessageBus` to publish floe traffic for remote workers without changing existing flows.
+* **Remote calls (opt-in)** — `RemoteNode` bridges the runtime to external agents through a
+  pluggable `RemoteTransport` interface (A2A-ready) while propagating streaming chunks and
+  cancellation.
 
 Built on pure `asyncio` (no threads), PenguiFlow is small, predictable, and repo-agnostic.
 Product repos only define **their models + node functions** — the core stays dependency-light.
@@ -186,6 +189,14 @@ sacrificing backpressure or ordering guarantees.  The helper wraps the payload i
 `StreamChunk`, mirrors routing metadata from the parent message, and automatically
 increments per-stream sequence numbers.  See `tests/test_streaming.py` and
 `examples/streaming_llm/` for an end-to-end walk-through.
+
+### Remote orchestration
+
+Phase 2 introduces `RemoteNode` and the `RemoteTransport` protocol so flows can delegate
+work to remote agents (e.g., the A2A JSON-RPC/SSE ecosystem) without changing existing
+nodes.  The helper records remote bindings via the `StateStore`, mirrors streaming
+partials back into the graph, and propagates per-trace cancellation to remote tasks via
+`RemoteTransport.cancel`.  See `tests/test_remote.py` for reference in-memory transports.
 
 ### Reliability & guardrails
 

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -13,6 +13,7 @@ contributors understand how the pieces fit together.
 | `state.py` | Protocols for pluggable state stores plus the `StoredEvent`/`RemoteBinding` dataclasses. |
 | `bus.py` | Message bus protocol used to fan out floe traffic to remote workers. |
 | `node.py` | `Node` wrapper and `NodePolicy` configuration (validation scope, timeout, retry/backoff). |
+| `remote.py` | RemoteTransport protocol plus the `RemoteNode` helper for opt-in agent-to-agent calls. |
 | `types.py` | Pydantic models for headers, messages (with `Message.meta` bag), and controller/state artifacts (`WM`, `Thought`, `FinalAnswer`). |
 | `registry.py` | `ModelRegistry` that caches `TypeAdapter`s for per-node validation. |
 | `patterns.py` | Batteries-included helpers: `map_concurrent`, routers, and `join_k` aggregator. |
@@ -41,6 +42,11 @@ contributors understand how the pieces fit together.
   exposes the trace timeline) and every floe publish also emits a `BusEnvelope` describing
   the edge, trace id, headers, and metadata. Failures are logged but never surface to
   user code so adapters can fail independently of the core engine.
+* **Remote delegation**: `remote.RemoteNode` wraps remote execution through a
+  `RemoteTransport`. Bindings (`trace_id` ↔ remote context/task) persist via the
+  configured `StateStore`, streaming updates reuse `Context.emit_chunk`, and per-trace
+  cancellation mirrors to remote transports via `PenguiFlow.ensure_trace_event` and
+  `RemoteTransport.cancel`.
 * **Traceable exceptions**: when retries are exhausted or timeouts fire, the runtime
   builds a `FlowError` capturing the trace id, node metadata, and failure code. Setting
   `emit_errors_to_rookery=True` on `penguiflow.core.create` pushes the `FlowError`

--- a/penguiflow/__init__.py
+++ b/penguiflow/__init__.py
@@ -19,6 +19,13 @@ from .node import Node, NodePolicy
 from .patterns import join_k, map_concurrent, predicate_router, union_router
 from .policies import DictRoutingPolicy, RoutingPolicy, RoutingRequest
 from .registry import ModelRegistry
+from .remote import (
+    RemoteCallRequest,
+    RemoteCallResult,
+    RemoteNode,
+    RemoteStreamEvent,
+    RemoteTransport,
+)
 from .state import RemoteBinding, StateStore, StoredEvent
 from .streaming import (
     chunk_to_ws_json,
@@ -70,6 +77,11 @@ __all__ = [
     "StateStore",
     "StoredEvent",
     "RemoteBinding",
+    "RemoteTransport",
+    "RemoteCallRequest",
+    "RemoteCallResult",
+    "RemoteStreamEvent",
+    "RemoteNode",
 ]
 
 __version__ = "2.1.0a0"

--- a/penguiflow/remote.py
+++ b/penguiflow/remote.py
@@ -1,0 +1,222 @@
+"""Remote transport protocol and helper node for PenguiFlow."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+from .core import TraceCancelled
+from .node import Node, NodePolicy
+from .state import RemoteBinding
+from .types import Message
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from .core import Context, PenguiFlow
+
+
+@dataclass(slots=True)
+class RemoteCallRequest:
+    """Input to :class:`RemoteTransport` implementations."""
+
+    message: Message
+    skill: str
+    agent_url: str
+    agent_card: Mapping[str, Any] | None = None
+    metadata: Mapping[str, Any] | None = None
+    timeout_s: float | None = None
+
+
+@dataclass(slots=True)
+class RemoteCallResult:
+    """Return value for :meth:`RemoteTransport.send`."""
+
+    result: Any
+    context_id: str | None = None
+    task_id: str | None = None
+    agent_url: str | None = None
+    meta: Mapping[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class RemoteStreamEvent:
+    """Streaming event yielded by :meth:`RemoteTransport.stream`."""
+
+    text: str | None = None
+    done: bool = False
+    meta: Mapping[str, Any] | None = None
+    context_id: str | None = None
+    task_id: str | None = None
+    agent_url: str | None = None
+    result: Any | None = None
+
+
+class RemoteTransport(Protocol):
+    """Protocol describing the minimal remote invocation surface."""
+
+    async def send(self, request: RemoteCallRequest) -> RemoteCallResult:
+        """Perform a unary remote call."""
+
+    def stream(self, request: RemoteCallRequest) -> AsyncIterator[RemoteStreamEvent]:
+        """Perform a remote call that yields streaming events."""
+
+    async def cancel(self, *, agent_url: str, task_id: str) -> None:
+        """Cancel a remote task identified by ``task_id`` at ``agent_url``."""
+
+
+def RemoteNode(
+    *,
+    transport: RemoteTransport,
+    skill: str,
+    agent_url: str,
+    name: str,
+    agent_card: Mapping[str, Any] | None = None,
+    policy: NodePolicy | None = None,
+    streaming: bool = False,
+    record_binding: bool = True,
+) -> Node:
+    """Create a node that proxies work to a remote agent via ``transport``."""
+
+    node_policy = policy or NodePolicy()
+
+    async def _record_binding(
+        *,
+        runtime: PenguiFlow,
+        trace_id: str,
+        context_id: str | None,
+        task_id: str | None,
+        agent_url_override: str | None,
+    ) -> tuple[asyncio.Task[None], asyncio.Event] | None:
+        if context_id is None or task_id is None:
+            return None
+
+        agent_ref = agent_url_override or agent_url
+
+        if record_binding:
+            binding = RemoteBinding(
+                trace_id=trace_id,
+                context_id=context_id,
+                task_id=task_id,
+                agent_url=agent_ref,
+            )
+            await runtime.save_remote_binding(binding)
+
+        cancel_event = runtime.ensure_trace_event(trace_id)
+        if cancel_event.is_set():
+            with suppress(Exception):
+                await transport.cancel(agent_url=agent_ref, task_id=task_id)
+            raise TraceCancelled(trace_id)
+
+        async def _mirror_cancel() -> None:
+            try:
+                await cancel_event.wait()
+            except asyncio.CancelledError:
+                return
+            with suppress(Exception):
+                await transport.cancel(agent_url=agent_ref, task_id=task_id)
+
+        cancel_task = asyncio.create_task(_mirror_cancel())
+        runtime.register_external_task(trace_id, cancel_task)
+        return cancel_task, cancel_event
+
+    async def _remote_impl(message: Message, ctx: Context) -> Any:
+        if not isinstance(message, Message):
+            raise TypeError("Remote nodes require penguiflow.types.Message inputs")
+
+        runtime = ctx.runtime
+        if runtime is None:
+            raise RuntimeError("Context is not bound to a running PenguiFlow")
+
+        trace_id = message.trace_id
+        cancel_task: asyncio.Task[None] | None = None
+        cancel_event: asyncio.Event | None = None
+        binding_registered = False
+
+        request = RemoteCallRequest(
+            message=message,
+            skill=skill,
+            agent_url=agent_url,
+            agent_card=agent_card,
+            metadata=message.meta,
+            timeout_s=node_policy.timeout_s,
+        )
+
+        async def _ensure_binding(
+            *,
+            context_id: str | None,
+            task_id: str | None,
+            agent_url_override: str | None,
+        ) -> None:
+            nonlocal cancel_task, cancel_event, binding_registered
+            if binding_registered:
+                return
+            if context_id is None or task_id is None:
+                return
+            record = await _record_binding(
+                runtime=runtime,
+                trace_id=trace_id,
+                context_id=context_id,
+                task_id=task_id,
+                agent_url_override=agent_url_override,
+            )
+            if record is None:
+                return
+            cancel_task, cancel_event = record
+            binding_registered = True
+
+        async def _cleanup_cancel_task() -> None:
+            if cancel_task is not None:
+                if cancel_event is not None and cancel_event.is_set():
+                    with suppress(BaseException):
+                        await cancel_task
+                    return
+                if not cancel_task.done():
+                    cancel_task.cancel()
+                with suppress(BaseException):
+                    await cancel_task
+
+        try:
+            if streaming:
+                final_result: Any | None = None
+                async for event in transport.stream(request):
+                    await _ensure_binding(
+                        context_id=event.context_id,
+                        task_id=event.task_id,
+                        agent_url_override=event.agent_url,
+                    )
+                    if event.text is not None:
+                        meta = dict(event.meta) if event.meta is not None else None
+                        await ctx.emit_chunk(
+                            parent=message,
+                            text=event.text,
+                            done=event.done,
+                            meta=meta,
+                        )
+                    if event.result is not None:
+                        final_result = event.result
+                return final_result
+
+            result = await transport.send(request)
+            await _ensure_binding(
+                context_id=result.context_id,
+                task_id=result.task_id,
+                agent_url_override=result.agent_url,
+            )
+            return result.result
+        except TraceCancelled:
+            raise
+        finally:
+            await _cleanup_cancel_task()
+
+    return Node(_remote_impl, name=name, policy=node_policy)
+
+
+__all__ = [
+    "RemoteCallRequest",
+    "RemoteCallResult",
+    "RemoteStreamEvent",
+    "RemoteTransport",
+    "RemoteNode",
+]

--- a/tests/remote/README.md
+++ b/tests/remote/README.md
@@ -1,0 +1,14 @@
+# Remote call tests
+
+This suite documents `tests/test_remote.py`, which exercises PenguiFlow's
+phase 2 remote-call surface:
+
+* `RemoteNode` delegates unary requests through a `RemoteTransport` and
+  persists remote bindings via the configured `StateStore`.
+* Streaming transports feed partial output through `Context.emit_chunk`
+  while still returning a terminal payload to downstream nodes.
+* Cancelling a trace mirrors to the remote transport via the
+  `RemoteTransport.cancel` hook so remote agents can unwind their work.
+
+The tests rely on in-memory fakes and run entirely within the async runtime
+used by the rest of the test suite.

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from penguiflow import Headers, Message, RemoteNode, StreamChunk, create
+from penguiflow.remote import (
+    RemoteCallRequest,
+    RemoteCallResult,
+    RemoteStreamEvent,
+    RemoteTransport,
+)
+from penguiflow.state import RemoteBinding, StateStore, StoredEvent
+
+
+class RecordingStateStore(StateStore):
+    def __init__(self) -> None:
+        self.events: list[StoredEvent] = []
+        self.bindings: list[RemoteBinding] = []
+
+    async def save_event(self, event: StoredEvent) -> None:
+        self.events.append(event)
+
+    async def load_history(self, trace_id: str) -> list[StoredEvent]:
+        return [event for event in self.events if event.trace_id == trace_id]
+
+    async def save_remote_binding(self, binding: RemoteBinding) -> None:
+        self.bindings.append(binding)
+
+
+class UnaryTransport(RemoteTransport):
+    def __init__(self) -> None:
+        self.sent: list[RemoteCallRequest] = []
+        self.cancelled: list[tuple[str, str]] = []
+
+    async def send(self, request: RemoteCallRequest) -> RemoteCallResult:
+        self.sent.append(request)
+        return RemoteCallResult(
+            result={"answer": 42},
+            context_id="ctx-send",
+            task_id="task-send",
+            agent_url=request.agent_url,
+        )
+
+    async def stream(self, request: RemoteCallRequest):  # pragma: no cover - unary path
+        raise AssertionError("stream() should not be called in unary tests")
+
+    async def cancel(self, *, agent_url: str, task_id: str) -> None:
+        self.cancelled.append((agent_url, task_id))
+
+
+class StreamingTransport(RemoteTransport):
+    def __init__(self) -> None:
+        self.requests: list[RemoteCallRequest] = []
+        self.cancelled: list[tuple[str, str]] = []
+        self._finish = asyncio.Event()
+
+    async def send(self, request: RemoteCallRequest):
+        raise AssertionError("send() should not be called in streaming tests")
+
+    async def stream(self, request: RemoteCallRequest):
+        self.requests.append(request)
+        yield RemoteStreamEvent(
+            text="chunk-1",
+            context_id="ctx-stream",
+            task_id="task-stream",
+            agent_url=request.agent_url,
+            meta={"index": 0},
+        )
+        await self._finish.wait()
+        yield RemoteStreamEvent(
+            result={"final": True},
+            done=True,
+            task_id="task-stream",
+            agent_url=request.agent_url,
+        )
+
+    async def cancel(self, *, agent_url: str, task_id: str) -> None:
+        self.cancelled.append((agent_url, task_id))
+        self._finish.set()
+
+
+class CancelAwareTransport(RemoteTransport):
+    def __init__(self) -> None:
+        self.requests: list[RemoteCallRequest] = []
+        self.cancelled: list[tuple[str, str]] = []
+        self._finish = asyncio.Event()
+        self.cancelled_event = asyncio.Event()
+
+    async def send(self, request: RemoteCallRequest):
+        raise AssertionError("send() should not be called")
+
+    async def stream(self, request: RemoteCallRequest):
+        self.requests.append(request)
+        yield RemoteStreamEvent(
+            text="to-cancel",
+            context_id="ctx-cancel",
+            task_id="task-cancel",
+            agent_url=request.agent_url,
+        )
+        await self._finish.wait()
+        yield RemoteStreamEvent(
+            result={"final": "ignored"},
+            done=True,
+            task_id="task-cancel",
+            agent_url=request.agent_url,
+        )
+
+    async def cancel(self, *, agent_url: str, task_id: str) -> None:
+        self.cancelled.append((agent_url, task_id))
+        self.cancelled_event.set()
+        self._finish.set()
+
+
+@pytest.mark.asyncio
+async def test_remote_node_unary_call_records_binding() -> None:
+    store = RecordingStateStore()
+    transport = UnaryTransport()
+    node = RemoteNode(
+        transport=transport,
+        skill="SearchAgent.find",
+        agent_url="https://agent.example",
+        name="remote-search",
+    )
+    flow = create(node.to(), state_store=store)
+    flow.run()
+
+    message = Message(payload={"query": "penguins"}, headers=Headers(tenant="acme"))
+
+    try:
+        await flow.emit(message)
+        result = await flow.fetch()
+    finally:
+        await flow.stop()
+
+    assert result == {"answer": 42}
+    assert transport.sent
+    sent_message = transport.sent[0].message
+    assert sent_message.payload == message.payload
+    assert sent_message.headers == message.headers
+    assert store.bindings == [
+        RemoteBinding(
+            trace_id=message.trace_id,
+            context_id="ctx-send",
+            task_id="task-send",
+            agent_url="https://agent.example",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remote_node_streams_chunks_and_returns_final_result() -> None:
+    store = RecordingStateStore()
+    transport = StreamingTransport()
+    node = RemoteNode(
+        transport=transport,
+        skill="Writer.draft",
+        agent_url="https://agent.example",
+        name="remote-writer",
+        streaming=True,
+    )
+    flow = create(node.to(), state_store=store)
+    flow.run()
+
+    message = Message(payload={"prompt": "hello"}, headers=Headers(tenant="acme"))
+
+    try:
+        await flow.emit(message)
+        chunk_msg = await flow.fetch()
+        assert isinstance(chunk_msg, Message)
+        chunk = chunk_msg.payload
+        assert isinstance(chunk, StreamChunk)
+        assert chunk.text == "chunk-1"
+        transport._finish.set()
+        final = await flow.fetch()
+    finally:
+        await flow.stop()
+
+    assert final == {"final": True}
+    assert store.bindings[0].task_id == "task-stream"
+    assert not transport.cancelled
+
+
+@pytest.mark.asyncio
+async def test_remote_node_cancels_remote_task_on_trace_cancel() -> None:
+    store = RecordingStateStore()
+    transport = CancelAwareTransport()
+    node = RemoteNode(
+        transport=transport,
+        skill="Planner.plan",
+        agent_url="https://agent.example",
+        name="remote-planner",
+        streaming=True,
+    )
+    flow = create(node.to(), state_store=store)
+    flow.run()
+
+    message = Message(payload={"goal": "cancel"}, headers=Headers(tenant="acme"))
+
+    try:
+        await flow.emit(message)
+        first = await flow.fetch()
+        assert isinstance(first, Message)
+        chunk = first.payload
+        assert isinstance(chunk, StreamChunk)
+        assert chunk.text == "to-cancel"
+        trace_id = message.trace_id
+        cancelled = await flow.cancel(trace_id)
+        assert cancelled
+        await asyncio.wait_for(transport.cancelled_event.wait(), timeout=1.0)
+    finally:
+        await flow.stop()
+
+    assert transport.cancelled == [("https://agent.example", "task-cancel")]
+    assert store.bindings and store.bindings[0].task_id == "task-cancel"


### PR DESCRIPTION
## Summary
- prevent RemoteNode cleanup from raising CancelledError by tolerating BaseException when awaiting cancellation mirror tasks
- track external cancellation watcher tasks separately from invocation futures so PenguiFlow.stop can cancel them without breaking trace-level cancel propagation
- ensure all tracked tasks are cancelled during shutdown to avoid hanging pytest sessions

## Testing
- uv run python -m pytest
- uv run ruff check
- uv run mypy

------
https://chatgpt.com/codex/tasks/task_e_68db18ec65a083229612966d221e7c07