### PR TITLE
Implement JSON-based React planner and catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,21 @@ The new `penguiflow.testkit` module keeps unit tests tiny:
 The harness is covered by `tests/test_testkit.py` and demonstrated in
 `examples/testkit_demo/`.
 
+### JSON-only ReAct planner (Phase A)
+
+Phase A introduces a lightweight planner loop that keeps PenguiFlow typed and
+deterministic:
+
+* `penguiflow.catalog.NodeSpec` + `build_catalog` turn registered nodes into
+  tool descriptors with JSON Schemas derived from your Pydantic models.
+* `penguiflow.planner.ReactPlanner` drives a JSON-only ReAct loop over those
+  descriptors, validating every LLM action with Pydantic and replaying invalid
+  steps to request corrections.
+* LiteLLM stays optional—install `penguiflow[planner]` or inject a custom
+  `llm_client` for deterministic/offline runs.
+
+See `examples/react_minimal/` for a stubbed end-to-end run.
+
 
 ## 🧭 Repo Structure
 
@@ -581,6 +596,7 @@ pytest -q
 * `examples/streaming_llm/`: mock LLM emitting streaming chunks to an SSE sink.
 * `examples/metadata_propagation/`: attaching and consuming `Message.meta` context.
 * `examples/visualizer/`: exports Mermaid + DOT diagrams with loop/subflow annotations.
+* `examples/react_minimal/`: JSON-only ReactPlanner loop with a stubbed LLM.
 
 ---
 

--- a/examples/react_minimal/README.md
+++ b/examples/react_minimal/README.md
@@ -1,0 +1,8 @@
+# React planner minimal example
+
+This example demonstrates the Phase A JSON-only planner loop using a stubbed LLM.
+Run it with:
+
+```bash
+uv run python examples/react_minimal/main.py
+```

--- a/examples/react_minimal/main.py
+++ b/examples/react_minimal/main.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import BaseModel
+
+from penguiflow.catalog import build_catalog, tool
+from penguiflow.node import Node
+from penguiflow.planner import ReactPlanner
+from penguiflow.registry import ModelRegistry
+
+
+class Question(BaseModel):
+    text: str
+
+
+class Intent(BaseModel):
+    intent: str
+
+
+class Documents(BaseModel):
+    documents: list[str]
+
+
+class FinalAnswer(BaseModel):
+    answer: str
+
+
+@tool(desc="Detect the caller intent", tags=["planner"])
+async def triage(args: Question, ctx: object) -> Intent:
+    return Intent(intent="docs")
+
+
+@tool(desc="Retrieve supporting documents", side_effects="read")
+async def retrieve(args: Intent, ctx: object) -> Documents:
+    return Documents(documents=[f"PenguiFlow remains lightweight for {args.intent}"])
+
+
+@tool(desc="Summarise retrieved documents")
+async def summarise(args: FinalAnswer, ctx: object) -> FinalAnswer:
+    return args
+
+
+class SequenceLLM:
+    """Deterministic stub that returns pre-authored planner actions."""
+
+    def __init__(self, responses: list[Mapping[str, Any]]) -> None:
+        self._responses = [json.dumps(item) for item in responses]
+
+    async def complete(
+        self,
+        *,
+        messages: list[Mapping[str, str]],
+        response_format: Mapping[str, Any] | None = None,
+    ) -> str:
+        del messages, response_format
+        if not self._responses:
+            raise RuntimeError("SequenceLLM has no responses left")
+        return self._responses.pop(0)
+
+
+async def main() -> None:
+    registry = ModelRegistry()
+    registry.register("triage", Question, Intent)
+    registry.register("retrieve", Intent, Documents)
+    registry.register("summarise", FinalAnswer, FinalAnswer)
+
+    nodes = [
+        Node(triage, name="triage"),
+        Node(retrieve, name="retrieve"),
+        Node(summarise, name="summarise"),
+    ]
+
+    client = SequenceLLM(
+        [
+            {
+                "thought": "triage",
+                "next_node": "triage",
+                "args": {"text": "How does PenguiFlow stay lightweight?"},
+            },
+            {
+                "thought": "retrieve",
+                "next_node": "retrieve",
+                "args": {"intent": "docs"},
+            },
+            {
+                "thought": "wrap up",
+                "next_node": None,
+                "args": {
+                    "answer": "PenguiFlow uses async orchestration and minimal deps."
+                },
+            },
+        ]
+    )
+
+    planner = ReactPlanner(
+        llm_client=client,
+        catalog=build_catalog(nodes, registry),
+    )
+
+    result = await planner.run("Explain PenguiFlow's lightweight design")
+    print(json.dumps(result.model_dump(), indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/penguiflow/README.md
+++ b/penguiflow/README.md
@@ -13,6 +13,7 @@ contributors understand how the pieces fit together.
 | `state.py` | Protocols for pluggable state stores plus the `StoredEvent`/`RemoteBinding` dataclasses. |
 | `bus.py` | Message bus protocol used to fan out floe traffic to remote workers. |
 | `node.py` | `Node` wrapper and `NodePolicy` configuration (validation scope, timeout, retry/backoff). |
+| `catalog.py` | `NodeSpec` dataclass, tool decorator, and catalog builder feeding the planner. |
 | `remote.py` | RemoteTransport protocol plus the `RemoteNode` helper for opt-in agent-to-agent calls. |
 | `types.py` | Pydantic models for headers, messages (with `Message.meta` bag), and controller/state artifacts (`WM`, `Thought`, `FinalAnswer`). |
 | `registry.py` | `ModelRegistry` that caches `TypeAdapter`s for per-node validation. |
@@ -22,6 +23,7 @@ contributors understand how the pieces fit together.
 | `metrics.py` | `FlowEvent` model plus helpers for deriving metrics/tags. |
 | `viz.py` | Mermaid and DOT exporters with loop/subflow annotations. |
 | `testkit.py` | FlowTestKit helpers (`run_one`, `assert_node_sequence`, `simulate_error`). |
+| `planner/` | React planner loop (`ReactPlanner`, prompt helpers) building on catalog metadata. |
 | `__init__.py` | Public surface that re-exports the main primitives for consumers. |
 | `admin.py` | Developer CLI helpers (`penguiflow-admin`) for inspecting trace history. |
 
@@ -31,6 +33,9 @@ The `penguiflow_a2a` package ships separately and contains the FastAPI adapter u
 expose PenguiFlow graphs via the A2A protocol. Installing the `a2a-server` extra adds the
 `A2AServerAdapter`, request models, and the `create_a2a_app` helper without introducing
 FastAPI as a core dependency.
+
+Install the `planner` extra to pull in LiteLLM when you want the planner to call hosted
+models; otherwise you can inject a deterministic stub via the `llm_client` parameter.
 
 ## Key runtime behaviors
 

--- a/penguiflow/__init__.py
+++ b/penguiflow/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from . import testkit
 from .bus import BusEnvelope, MessageBus
+from .catalog import NodeSpec, SideEffect, build_catalog, tool
 from .core import (
     DEFAULT_QUEUE_MAXSIZE,
     Context,
@@ -17,6 +18,13 @@ from .metrics import FlowEvent
 from .middlewares import Middleware
 from .node import Node, NodePolicy
 from .patterns import join_k, map_concurrent, predicate_router, union_router
+from .planner import (
+    PlannerAction,
+    PlannerFinish,
+    ReactPlanner,
+    Trajectory,
+    TrajectoryStep,
+)
 from .policies import DictRoutingPolicy, RoutingPolicy, RoutingRequest
 from .registry import ModelRegistry
 from .remote import (
@@ -45,6 +53,10 @@ __all__ = [
     "Node",
     "NodePolicy",
     "ModelRegistry",
+    "NodeSpec",
+    "SideEffect",
+    "build_catalog",
+    "tool",
     "Middleware",
     "FlowEvent",
     "FlowError",
@@ -82,6 +94,11 @@ __all__ = [
     "RemoteCallResult",
     "RemoteStreamEvent",
     "RemoteNode",
+    "ReactPlanner",
+    "PlannerAction",
+    "PlannerFinish",
+    "Trajectory",
+    "TrajectoryStep",
 ]
 
 __version__ = "2.1.0"

--- a/penguiflow/catalog.py
+++ b/penguiflow/catalog.py
@@ -1,0 +1,146 @@
+"""Tool catalog helpers for the planner."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel
+
+from .node import Node
+from .registry import ModelRegistry
+
+SideEffect = Literal["pure", "read", "write", "external", "stateful"]
+
+
+@dataclass(frozen=True, slots=True)
+class NodeSpec:
+    """Structured metadata describing a planner-discoverable node."""
+
+    node: Node
+    name: str
+    desc: str
+    args_model: type[BaseModel]
+    out_model: type[BaseModel]
+    side_effects: SideEffect = "pure"
+    tags: Sequence[str] = field(default_factory=tuple)
+    auth_scopes: Sequence[str] = field(default_factory=tuple)
+    cost_hint: str | None = None
+    latency_hint_ms: int | None = None
+    safety_notes: str | None = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_tool_record(self) -> dict[str, Any]:
+        """Convert the spec to a serialisable record for prompting."""
+
+        return {
+            "name": self.name,
+            "desc": self.desc,
+            "side_effects": self.side_effects,
+            "tags": list(self.tags),
+            "auth_scopes": list(self.auth_scopes),
+            "cost_hint": self.cost_hint,
+            "latency_hint_ms": self.latency_hint_ms,
+            "safety_notes": self.safety_notes,
+            "args_schema": self.args_model.model_json_schema(),
+            "out_schema": self.out_model.model_json_schema(),
+            "extra": dict(self.extra),
+        }
+
+
+def _normalise_sequence(value: Sequence[str] | None) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    return tuple(dict.fromkeys(value))
+
+
+def tool(
+    *,
+    desc: str | None = None,
+    side_effects: SideEffect = "pure",
+    tags: Sequence[str] | None = None,
+    auth_scopes: Sequence[str] | None = None,
+    cost_hint: str | None = None,
+    latency_hint_ms: int | None = None,
+    safety_notes: str | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Annotate a node function with catalog metadata."""
+
+    payload: dict[str, Any] = {
+        "desc": desc,
+        "side_effects": side_effects,
+        "tags": _normalise_sequence(tags),
+        "auth_scopes": _normalise_sequence(auth_scopes),
+        "cost_hint": cost_hint,
+        "latency_hint_ms": latency_hint_ms,
+        "safety_notes": safety_notes,
+        "extra": dict(extra) if extra else {},
+    }
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        func_ref = cast(Any, func)
+        func_ref.__penguiflow_tool__ = payload
+        return func
+
+    return decorator
+
+
+def _load_metadata(func: Callable[..., Any]) -> dict[str, Any]:
+    raw = getattr(func, "__penguiflow_tool__", None)
+    if not raw:
+        return {
+            "desc": inspect.getdoc(func) or func.__name__,
+            "side_effects": "pure",
+            "tags": (),
+            "auth_scopes": (),
+            "cost_hint": None,
+            "latency_hint_ms": None,
+            "safety_notes": None,
+            "extra": {},
+        }
+    return {
+        "desc": raw.get("desc") or inspect.getdoc(func) or func.__name__,
+        "side_effects": raw.get("side_effects", "pure"),
+        "tags": tuple(raw.get("tags", ())),
+        "auth_scopes": tuple(raw.get("auth_scopes", ())),
+        "cost_hint": raw.get("cost_hint"),
+        "latency_hint_ms": raw.get("latency_hint_ms"),
+        "safety_notes": raw.get("safety_notes"),
+        "extra": dict(raw.get("extra", {})),
+    }
+
+
+def build_catalog(
+    nodes: Sequence[Node],
+    registry: ModelRegistry,
+) -> list[NodeSpec]:
+    """Derive :class:`NodeSpec` objects from runtime nodes."""
+
+    specs: list[NodeSpec] = []
+    for node in nodes:
+        node_name = node.name or node.func.__name__
+        in_model, out_model = registry.models(node_name)
+        metadata = _load_metadata(node.func)
+        specs.append(
+            NodeSpec(
+                node=node,
+                name=node_name,
+                desc=metadata["desc"],
+                args_model=in_model,
+                out_model=out_model,
+                side_effects=metadata["side_effects"],
+                tags=metadata["tags"],
+                auth_scopes=metadata["auth_scopes"],
+                cost_hint=metadata["cost_hint"],
+                latency_hint_ms=metadata["latency_hint_ms"],
+                safety_notes=metadata["safety_notes"],
+                extra=metadata["extra"],
+            )
+        )
+    return specs
+
+
+__all__ = ["NodeSpec", "SideEffect", "build_catalog", "tool"]

--- a/penguiflow/planner/__init__.py
+++ b/penguiflow/planner/__init__.py
@@ -1,0 +1,19 @@
+"""Planner entry points."""
+
+from __future__ import annotations
+
+from .react import (
+    PlannerAction,
+    PlannerFinish,
+    ReactPlanner,
+    Trajectory,
+    TrajectoryStep,
+)
+
+__all__ = [
+    "PlannerAction",
+    "PlannerFinish",
+    "ReactPlanner",
+    "Trajectory",
+    "TrajectoryStep",
+]

--- a/penguiflow/planner/prompts.py
+++ b/penguiflow/planner/prompts.py
@@ -81,6 +81,13 @@ def render_validation_error(node_name: str, error: str) -> str:
     )
 
 
+def render_output_validation_error(node_name: str, error: str) -> str:
+    return (
+        f"tool '{node_name}' returned data that did not validate: {error}. "
+        "Ensure the tool output matches the declared schema."
+    )
+
+
 def render_invalid_node(node_name: str, available: Sequence[str]) -> str:
     options = ", ".join(sorted(available))
     return (

--- a/penguiflow/planner/prompts.py
+++ b/penguiflow/planner/prompts.py
@@ -1,0 +1,95 @@
+"""Prompt helpers for the React planner."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def _compact_json(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True)
+
+
+def render_tool(record: Mapping[str, Any]) -> str:
+    args_schema = _compact_json(record["args_schema"])
+    out_schema = _compact_json(record["out_schema"])
+    tags = ", ".join(record.get("tags", ()))
+    scopes = ", ".join(record.get("auth_scopes", ()))
+    parts = [
+        f"- name: {record['name']}",
+        f"  desc: {record['desc']}",
+        f"  side_effects: {record['side_effects']}",
+        f"  args_schema: {args_schema}",
+        f"  out_schema: {out_schema}",
+    ]
+    if tags:
+        parts.append(f"  tags: {tags}")
+    if scopes:
+        parts.append(f"  auth_scopes: {scopes}")
+    if record.get("cost_hint"):
+        parts.append(f"  cost_hint: {record['cost_hint']}")
+    if record.get("latency_hint_ms") is not None:
+        parts.append(f"  latency_hint_ms: {record['latency_hint_ms']}")
+    if record.get("safety_notes"):
+        parts.append(f"  safety_notes: {record['safety_notes']}")
+    if record.get("extra"):
+        parts.append(f"  extra: {_compact_json(record['extra'])}")
+    return "\n".join(parts)
+
+
+def build_system_prompt(
+    catalog: Sequence[Mapping[str, Any]],
+    *,
+    extra: str | None = None,
+) -> str:
+    rendered_tools = "\n".join(render_tool(item) for item in catalog)
+    prompt = [
+        "You are PenguiFlow ReactPlanner, a JSON-only planner.",
+        "Follow these rules strictly:",
+        "1. Respond with valid JSON matching the PlannerAction schema.",
+        "2. Use the provided tools when necessary; never invent new tool names.",
+        "3. Keep 'thought' concise and factual.",
+        "4. When the task is complete, set 'next_node' to null "
+        "and include the final payload in 'args'.",
+        "5. Do not emit plain text outside JSON.",
+        "",
+        "Available tools:",
+        rendered_tools or "(none)",
+    ]
+    if extra:
+        prompt.extend(["", "Additional guidance:", extra])
+    return "\n".join(prompt)
+
+
+def build_user_prompt(query: str, context_meta: Mapping[str, Any] | None = None) -> str:
+    if context_meta:
+        return _compact_json({"query": query, "context": dict(context_meta)})
+    return _compact_json({"query": query})
+
+
+def render_observation(*, observation: Any | None, error: str | None) -> str:
+    if error:
+        return f"Observation: ERROR {error}"
+    return f"Observation: {_compact_json(observation)}"
+
+
+def render_validation_error(node_name: str, error: str) -> str:
+    return (
+        f"args for tool '{node_name}' did not validate: {error}. "
+        "Return corrected JSON."
+    )
+
+
+def render_invalid_node(node_name: str, available: Sequence[str]) -> str:
+    options = ", ".join(sorted(available))
+    return (
+        f"tool '{node_name}' is not in the catalog. Choose one of: {options}."
+    )
+
+
+def render_repair_message(error: str) -> str:
+    return (
+        "Previous response was invalid JSON or schema mismatch: "
+        f"{error}. Reply with corrected JSON only."
+    )

--- a/penguiflow/planner/react.py
+++ b/penguiflow/planner/react.py
@@ -229,7 +229,16 @@ class ReactPlanner:
                     error=error,
                 )
 
-            observation = spec.out_model.model_validate(result)
+            try:
+                observation = spec.out_model.model_validate(result)
+            except ValidationError as exc:
+                error = prompts.render_output_validation_error(
+                    spec.name,
+                    json.dumps(exc.errors(), ensure_ascii=False),
+                )
+                trajectory.steps.append(TrajectoryStep(action=action, error=error))
+                continue
+
             trajectory.steps.append(
                 TrajectoryStep(action=action, observation=observation)
             )

--- a/penguiflow/planner/react.py
+++ b/penguiflow/planner/react.py
@@ -1,0 +1,328 @@
+"""JSON-only ReAct planner loop."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field, ValidationError
+
+from ..catalog import NodeSpec, build_catalog
+from ..node import Node
+from ..registry import ModelRegistry
+from . import prompts
+
+
+class JSONLLMClient(Protocol):
+    async def complete(
+        self,
+        *,
+        messages: Sequence[Mapping[str, str]],
+        response_format: Mapping[str, Any] | None = None,
+    ) -> str:
+        ...
+
+
+class PlannerAction(BaseModel):
+    thought: str
+    next_node: str | None = None
+    args: dict[str, Any] | None = None
+    plan: list[dict[str, Any]] | None = None
+    join: dict[str, Any] | None = None
+
+
+class PlannerFinish(BaseModel):
+    reason: str
+    payload: Any = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TrajectoryStep:
+    action: PlannerAction
+    observation: Any | None = None
+    error: str | None = None
+
+    def dump(self) -> dict[str, Any]:
+        return {
+            "action": self.action.model_dump(mode="json"),
+            "observation": self._serialise_observation(),
+            "error": self.error,
+        }
+
+    def _serialise_observation(self) -> Any:
+        if isinstance(self.observation, BaseModel):
+            return self.observation.model_dump(mode="json")
+        return self.observation
+
+
+@dataclass(slots=True)
+class Trajectory:
+    query: str
+    context_meta: Mapping[str, Any] | None = None
+    steps: list[TrajectoryStep] = field(default_factory=list)
+
+    def to_history(self) -> list[dict[str, Any]]:
+        return [step.dump() for step in self.steps]
+
+
+class _LiteLLMJSONClient:
+    def __init__(
+        self,
+        llm: str | Mapping[str, Any],
+        *,
+        temperature: float,
+        json_schema_mode: bool,
+    ) -> None:
+        self._llm = llm
+        self._temperature = temperature
+        self._json_schema_mode = json_schema_mode
+
+    async def complete(
+        self,
+        *,
+        messages: Sequence[Mapping[str, str]],
+        response_format: Mapping[str, Any] | None = None,
+    ) -> str:
+        try:
+            import litellm
+        except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+            raise RuntimeError(
+                "LiteLLM is not installed. Install penguiflow[planner] or provide "
+                "a custom llm_client."
+            ) from exc
+
+        params: dict[str, Any]
+        if isinstance(self._llm, str):
+            params = {"model": self._llm}
+        else:
+            params = dict(self._llm)
+        params.setdefault("temperature", self._temperature)
+        params["messages"] = list(messages)
+        if self._json_schema_mode and response_format is not None:
+            params["response_format"] = response_format
+
+        response = await litellm.acompletion(**params)
+        choice = response["choices"][0]
+        content = choice["message"]["content"]
+        if content is None:
+            raise RuntimeError("LiteLLM returned empty content")
+        return content
+
+
+class _PlannerContext:
+    __slots__ = ("meta",)
+
+    def __init__(self, meta: Mapping[str, Any] | None = None) -> None:
+        self.meta = dict(meta) if meta else {}
+
+
+class ReactPlanner:
+    """Minimal JSON-only ReAct loop."""
+
+    def __init__(
+        self,
+        llm: str | Mapping[str, Any] | None = None,
+        *,
+        nodes: Sequence[Node] | None = None,
+        catalog: Sequence[NodeSpec] | None = None,
+        registry: ModelRegistry | None = None,
+        llm_client: JSONLLMClient | None = None,
+        max_iters: int = 8,
+        temperature: float = 0.0,
+        json_schema_mode: bool = True,
+        system_prompt_extra: str | None = None,
+        repair_attempts: int = 3,
+    ) -> None:
+        if catalog is None:
+            if nodes is None or registry is None:
+                raise ValueError(
+                    "Either catalog or (nodes and registry) must be provided"
+                )
+            catalog = build_catalog(nodes, registry)
+
+        self._specs = list(catalog)
+        self._spec_by_name = {spec.name: spec for spec in self._specs}
+        self._catalog_records = [spec.to_tool_record() for spec in self._specs]
+        self._system_prompt = prompts.build_system_prompt(
+            self._catalog_records,
+            extra=system_prompt_extra,
+        )
+        self._max_iters = max_iters
+        self._repair_attempts = repair_attempts
+        self._json_schema_mode = json_schema_mode
+        self._response_format = (
+            {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "planner_action",
+                    "schema": PlannerAction.model_json_schema(),
+                },
+            }
+            if json_schema_mode
+            else None
+        )
+        if llm_client is not None:
+            self._client = llm_client
+        else:
+            if llm is None:
+                raise ValueError("llm or llm_client must be provided")
+            self._client = _LiteLLMJSONClient(
+                llm,
+                temperature=temperature,
+                json_schema_mode=json_schema_mode,
+            )
+
+    async def run(
+        self,
+        query: str,
+        *,
+        context_meta: Mapping[str, Any] | None = None,
+    ) -> PlannerFinish:
+        trajectory = Trajectory(query=query, context_meta=context_meta)
+        last_observation: Any | None = None
+
+        for _ in range(self._max_iters):
+            action = await self.step(trajectory)
+
+            if action.next_node is None:
+                payload = action.args or last_observation
+                return self._finish(
+                    trajectory,
+                    reason="answer_complete",
+                    payload=payload,
+                    thought=action.thought,
+                )
+
+            spec = self._spec_by_name.get(action.next_node)
+            if spec is None:
+                error = prompts.render_invalid_node(
+                    action.next_node,
+                    list(self._spec_by_name.keys()),
+                )
+                trajectory.steps.append(TrajectoryStep(action=action, error=error))
+                continue
+
+            try:
+                parsed_args = spec.args_model.model_validate(action.args or {})
+            except ValidationError as exc:
+                error = prompts.render_validation_error(
+                    spec.name,
+                    json.dumps(exc.errors(), ensure_ascii=False),
+                )
+                trajectory.steps.append(TrajectoryStep(action=action, error=error))
+                continue
+
+            ctx = _PlannerContext(meta=context_meta)
+            try:
+                result = await spec.node.func(parsed_args, ctx)
+            except Exception as exc:  # pragma: no cover - surfaced via metadata
+                error = f"tool '{spec.name}' raised {exc.__class__.__name__}: {exc}"
+                trajectory.steps.append(TrajectoryStep(action=action, error=error))
+                return self._finish(
+                    trajectory,
+                    reason="error",
+                    payload=None,
+                    thought=action.thought,
+                    error=error,
+                )
+
+            observation = spec.out_model.model_validate(result)
+            trajectory.steps.append(
+                TrajectoryStep(action=action, observation=observation)
+            )
+            last_observation = observation.model_dump(mode="json")
+
+        return self._finish(
+            trajectory,
+            reason="no_path",
+            payload=last_observation,
+            thought="iteration limit reached",
+        )
+
+    async def step(self, trajectory: Trajectory) -> PlannerAction:
+        base_messages = self._build_messages(trajectory)
+        messages: list[dict[str, str]] = list(base_messages)
+        last_error: str | None = None
+
+        for _ in range(self._repair_attempts):
+            if last_error is not None:
+                messages = list(base_messages) + [
+                    {
+                        "role": "system",
+                        "content": prompts.render_repair_message(last_error),
+                    }
+                ]
+
+            raw = await self._client.complete(
+                messages=messages,
+                response_format=self._response_format,
+            )
+
+            try:
+                return PlannerAction.model_validate_json(raw)
+            except ValidationError as exc:
+                last_error = json.dumps(exc.errors(), ensure_ascii=False)
+                continue
+
+        raise RuntimeError("Planner failed to produce valid JSON after repair attempts")
+
+    def _build_messages(self, trajectory: Trajectory) -> list[dict[str, str]]:
+        messages: list[dict[str, str]] = [
+            {"role": "system", "content": self._system_prompt},
+            {
+                "role": "user",
+                "content": prompts.build_user_prompt(
+                    trajectory.query,
+                    trajectory.context_meta,
+                ),
+            },
+        ]
+
+        for step in trajectory.steps:
+            action_payload = json.dumps(
+                step.action.model_dump(mode="json"),
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            messages.append({"role": "assistant", "content": action_payload})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": prompts.render_observation(
+                        observation=step._serialise_observation(),
+                        error=step.error,
+                    ),
+                }
+            )
+        return messages
+
+    def _finish(
+        self,
+        trajectory: Trajectory,
+        *,
+        reason: str,
+        payload: Any,
+        thought: str,
+        error: str | None = None,
+    ) -> PlannerFinish:
+        metadata = {
+            "reason": reason,
+            "thought": thought,
+            "steps": trajectory.to_history(),
+            "step_count": len(trajectory.steps),
+        }
+        if error is not None:
+            metadata["error"] = error
+        return PlannerFinish(reason=reason, payload=payload, metadata=metadata)
+
+
+__all__ = [
+    "PlannerAction",
+    "PlannerFinish",
+    "ReactPlanner",
+    "Trajectory",
+    "TrajectoryStep",
+]

--- a/penguiflow/registry.py
+++ b/penguiflow/registry.py
@@ -15,6 +15,8 @@ ModelT = TypeVar("ModelT", bound=BaseModel)
 class RegistryEntry:
     in_adapter: TypeAdapter[Any]
     out_adapter: TypeAdapter[Any]
+    in_model: type[BaseModel]
+    out_model: type[BaseModel]
 
 
 class ModelRegistry:
@@ -36,6 +38,8 @@ class ModelRegistry:
         self._entries[node_name] = RegistryEntry(
             TypeAdapter(in_model),
             TypeAdapter(out_model),
+            in_model,
+            out_model,
         )
 
     def adapters(self, node_name: str) -> tuple[TypeAdapter[Any], TypeAdapter[Any]]:
@@ -44,6 +48,23 @@ class ModelRegistry:
         except KeyError as exc:
             raise KeyError(f"Node '{node_name}' not registered") from exc
         return entry.in_adapter, entry.out_adapter
+
+    def models(
+        self, node_name: str
+    ) -> tuple[type[BaseModel], type[BaseModel]]:
+        """Return the registered models for ``node_name``.
+
+        Raises
+        ------
+        KeyError
+            If the node has not been registered.
+        """
+
+        try:
+            entry = self._entries[node_name]
+        except KeyError as exc:
+            raise KeyError(f"Node '{node_name}' not registered") from exc
+        return entry.in_model, entry.out_model
 
 
 __all__ = ["ModelRegistry"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dev = [
 a2a-server = [
     "fastapi>=0.110",
 ]
+planner = [
+    "litellm>=1.40.0",
+]
 
 [project.scripts]
 penguiflow-admin = "penguiflow.admin:main"

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import BaseModel
+
+from penguiflow.catalog import build_catalog, tool
+from penguiflow.node import Node
+from penguiflow.registry import ModelRegistry
+
+
+class EchoArgs(BaseModel):
+    message: str
+
+
+class EchoOut(BaseModel):
+    echoed: str
+
+
+@tool(desc="Echo a message", tags=["utility", "utility"], side_effects="read")
+async def echo(args: EchoArgs, ctx: object) -> EchoOut:
+    """Echo helper."""
+
+    return EchoOut(echoed=args.message)
+
+
+async def describe(args: EchoArgs, ctx: object) -> EchoOut:
+    """Describe the payload."""
+
+    return EchoOut(echoed=f"desc:{args.message}")
+
+
+@pytest.fixture()
+def registry() -> ModelRegistry:
+    reg = ModelRegistry()
+    reg.register("echo", EchoArgs, EchoOut)
+    reg.register("describe", EchoArgs, EchoOut)
+    return reg
+
+
+def test_build_catalog_uses_metadata(registry: ModelRegistry) -> None:
+    node = Node(echo, name="echo")
+    specs = build_catalog([node], registry)
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.name == "echo"
+    assert spec.desc == "Echo a message"
+    assert spec.side_effects == "read"
+    assert spec.tags == ("utility",)
+    record = spec.to_tool_record()
+    assert record["args_schema"]["title"] == "EchoArgs"
+    assert json.loads(json.dumps(record["out_schema"]))["title"] == "EchoOut"
+
+
+def test_build_catalog_falls_back_to_docstring(registry: ModelRegistry) -> None:
+    node = Node(describe, name="describe")
+    specs = build_catalog([node], registry)
+    spec = specs[0]
+    assert spec.desc == "Describe the payload."
+    assert spec.side_effects == "pure"

--- a/tests/test_planner_prompts.py
+++ b/tests/test_planner_prompts.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from penguiflow.planner import prompts
+
+
+def test_render_tool_includes_optional_fields() -> None:
+    record = {
+        "name": "search",
+        "desc": "Lookup",
+        "side_effects": "read",
+        "args_schema": {"title": "Args"},
+        "out_schema": {"title": "Out"},
+        "tags": ["a", "b"],
+        "auth_scopes": ["scope"],
+        "cost_hint": "low",
+        "latency_hint_ms": 42,
+        "safety_notes": "careful",
+        "extra": {"foo": "bar"},
+    }
+    rendered = prompts.render_tool(record)
+    assert "tags" in rendered
+    assert "auth_scopes" in rendered
+    assert "extra" in rendered
+
+
+def test_build_system_prompt_appends_extra_guidance() -> None:
+    prompt = prompts.build_system_prompt([
+        {
+            "name": "tool",
+            "desc": "do",
+            "side_effects": "pure",
+            "args_schema": {},
+            "out_schema": {},
+        }
+    ], extra="Stay focused.")
+    assert "Stay focused." in prompt
+
+
+def test_build_user_prompt_serialises_context() -> None:
+    payload = prompts.build_user_prompt("question", {"tenant": "acme"})
+    assert "tenant" in payload
+
+
+def test_render_helpers() -> None:
+    error_obs = prompts.render_observation(observation=None, error="boom")
+    assert "ERROR" in error_obs
+    invalid = prompts.render_invalid_node("ghost", ["known"])
+    assert "ghost" in invalid
+    repair = prompts.render_repair_message("oops")
+    assert "oops" in repair

--- a/tests/test_planner_prompts.py
+++ b/tests/test_planner_prompts.py
@@ -44,6 +44,8 @@ def test_build_user_prompt_serialises_context() -> None:
 def test_render_helpers() -> None:
     error_obs = prompts.render_observation(observation=None, error="boom")
     assert "ERROR" in error_obs
+    output_error = prompts.render_output_validation_error("ghost", "bad")
+    assert "returned data" in output_error
     invalid = prompts.render_invalid_node("ghost", ["known"])
     assert "ghost" in invalid
     repair = prompts.render_repair_message("oops")

--- a/tests/test_react_planner.py
+++ b/tests/test_react_planner.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+import pytest
+from pydantic import BaseModel
+
+from penguiflow.catalog import build_catalog, tool
+from penguiflow.node import Node
+from penguiflow.planner import ReactPlanner
+from penguiflow.planner.react import Trajectory
+from penguiflow.registry import ModelRegistry
+
+
+class Query(BaseModel):
+    question: str
+
+
+class Intent(BaseModel):
+    intent: str
+
+
+class Documents(BaseModel):
+    documents: list[str]
+
+
+class Answer(BaseModel):
+    answer: str
+
+
+@tool(desc="Detect intent", tags=["nlp"])
+async def triage(args: Query, ctx: object) -> Intent:
+    return Intent(intent="docs")
+
+
+@tool(desc="Search knowledge base", side_effects="read")
+async def retrieve(args: Intent, ctx: object) -> Documents:
+    return Documents(documents=[f"Answering about {args.intent}"])
+
+
+@tool(desc="Compose final answer")
+async def respond(args: Answer, ctx: object) -> Answer:
+    return args
+
+
+class StubClient:
+    def __init__(self, responses: list[Mapping[str, object]]) -> None:
+        self._responses = [json.dumps(item) for item in responses]
+        self.calls: list[list[Mapping[str, str]]] = []
+
+    async def complete(
+        self,
+        *,
+        messages: list[Mapping[str, str]],
+        response_format: Mapping[str, object] | None = None,
+    ) -> str:
+        self.calls.append(list(messages))
+        if not self._responses:
+            raise AssertionError("No stub responses left")
+        return self._responses.pop(0)
+
+
+def make_planner(client: StubClient) -> ReactPlanner:
+    registry = ModelRegistry()
+    registry.register("triage", Query, Intent)
+    registry.register("retrieve", Intent, Documents)
+    registry.register("respond", Answer, Answer)
+
+    nodes = [
+        Node(triage, name="triage"),
+        Node(retrieve, name="retrieve"),
+        Node(respond, name="respond"),
+    ]
+    catalog = build_catalog(nodes, registry)
+    return ReactPlanner(llm_client=client, catalog=catalog)
+
+
+@pytest.mark.asyncio()
+async def test_react_planner_runs_end_to_end() -> None:
+    client = StubClient(
+        [
+            {
+                "thought": "triage",
+                "next_node": "triage",
+                "args": {"question": "What is PenguiFlow?"},
+            },
+            {
+                "thought": "retrieve",
+                "next_node": "retrieve",
+                "args": {"intent": "docs"},
+            },
+            {
+                "thought": "final",
+                "next_node": None,
+                "args": {"answer": "PenguiFlow is lightweight."},
+            },
+        ]
+    )
+    planner = make_planner(client)
+
+    result = await planner.run("Tell me about PenguiFlow")
+
+    assert result.reason == "answer_complete"
+    assert result.payload == {"answer": "PenguiFlow is lightweight."}
+    assert result.metadata["step_count"] == 2
+
+
+@pytest.mark.asyncio()
+async def test_react_planner_recovers_from_invalid_node() -> None:
+    client = StubClient(
+        [
+            {"thought": "invalid", "next_node": "missing", "args": {}},
+            {"thought": "triage", "next_node": "triage", "args": {"question": "What?"}},
+            {"thought": "finish", "next_node": None, "args": {"answer": "done"}},
+        ]
+    )
+    planner = make_planner(client)
+
+    result = await planner.run("Test invalid node")
+
+    assert result.reason == "answer_complete"
+    assert any("missing" in step["error"] for step in result.metadata["steps"])
+
+
+@pytest.mark.asyncio()
+async def test_react_planner_reports_validation_error() -> None:
+    client = StubClient(
+        [
+            {"thought": "bad", "next_node": "retrieve", "args": {}},
+            {
+                "thought": "triage",
+                "next_node": "triage",
+                "args": {"question": "Q"},
+            },
+            {
+                "thought": "retrieve",
+                "next_node": "retrieve",
+                "args": {"intent": "docs"},
+            },
+            {"thought": "finish", "next_node": None, "args": {"answer": "ok"}},
+        ]
+    )
+    planner = make_planner(client)
+
+    result = await planner.run("Test validation path")
+
+    errors = [step["error"] for step in result.metadata["steps"] if step["error"]]
+    assert any("did not validate" in err for err in errors)
+
+
+def test_react_planner_requires_catalog_or_nodes() -> None:
+    client = StubClient([])
+    with pytest.raises(ValueError):
+        ReactPlanner(llm_client=client)
+
+
+def test_react_planner_requires_llm_or_client() -> None:
+    registry = ModelRegistry()
+    registry.register("triage", Query, Intent)
+    nodes = [Node(triage, name="triage")]
+    with pytest.raises(ValueError):
+        ReactPlanner(nodes=nodes, registry=registry)
+
+
+@pytest.mark.asyncio()
+async def test_react_planner_iteration_limit_returns_no_path() -> None:
+    client = StubClient(
+        [
+            {
+                "thought": "loop",
+                "next_node": "triage",
+                "args": {"question": "still thinking"},
+            }
+        ]
+    )
+    registry = ModelRegistry()
+    registry.register("triage", Query, Intent)
+    planner = ReactPlanner(
+        llm_client=client,
+        catalog=build_catalog([Node(triage, name="triage")], registry),
+        max_iters=1,
+    )
+
+    result = await planner.run("Explain")
+    assert result.reason == "no_path"
+
+
+@pytest.mark.asyncio()
+async def test_react_planner_litellm_guard_raises_runtime_error() -> None:
+    registry = ModelRegistry()
+    registry.register("triage", Query, Intent)
+    nodes = [Node(triage, name="triage")]
+    planner = ReactPlanner(llm="dummy", nodes=nodes, registry=registry)
+    trajectory = Trajectory(query="hi")
+    with pytest.raises(RuntimeError) as exc:
+        await planner.step(trajectory)
+    assert "LiteLLM is not installed" in str(exc.value)
+
+
+@pytest.mark.asyncio()
+async def test_react_planner_step_repairs_invalid_action() -> None:
+    client = StubClient(
+        [
+            "{}",
+            {
+                "thought": "recover",
+                "next_node": "triage",
+                "args": {"question": "fixed"},
+            },
+        ]
+    )
+    planner = make_planner(client)
+    trajectory = Trajectory(query="recover")
+
+    action = await planner.step(trajectory)
+    assert action.next_node == "triage"
+    assert len(client.calls) == 2
+    repair_message = client.calls[1][-1]["content"]
+    assert "invalid JSON" in repair_message


### PR DESCRIPTION
## Summary
- add a catalog helper with NodeSpec metadata and registry integration for planner tooling
- implement the JSON-only ReactPlanner plus prompt utilities and expose them from the package
- document the new planner phase, ship a runnable react_minimal example, and cover the new code with unit tests

## Testing
- `uv run ruff check .`
- `uv run mypy penguiflow`
- `uv run --with pytest-cov --with pytest-asyncio --with fastapi --with httpx pytest --cov=penguiflow --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68dc4701c1288322ba6d5caa2d79a538