### PR TITLE
Add FlowTestKit diagnostics helper and coverage

### DIFF
--- a/llm.txt
+++ b/llm.txt
@@ -159,6 +159,7 @@ registry.register("enrich", Message, Message)
 **Guardrails for Message-aware nodes:**
 - **Runtime warning:** Nodes registered as `Message -> Message` now emit a `RuntimeWarning` if they return a bare payload. Return a `penguiflow.types.Message` so headers and trace IDs stay intact.
 - **Test helper:** Use `penguiflow.testkit.assert_preserves_message_envelope(...)` in unit tests to ensure Message-aware nodes keep the envelope unchanged.
+- **Flow diagnostics:** `penguiflow.testkit.get_recorded_events(trace_id)` exposes the immutable `FlowEvent` history captured by `run_one(...)` so you can assert `node_failed` payloads or verify `log_flow_events` output inside tests.
 - **Docs alignment:** This guidance is mirrored in `manual.md` so human- and model-facing docs stay consistent.
 
 ### Return vs Emit Decision
@@ -330,7 +331,12 @@ from penguiflow.errors import FlowError, FlowErrorCode
 from penguiflow.metrics import FlowEvent
 
 # Testing
-from penguiflow.testkit import run_one, assert_node_sequence, simulate_error
+from penguiflow.testkit import (
+    run_one,
+    assert_node_sequence,
+    simulate_error,
+    get_recorded_events,
+)
 
 # Visualization
 from penguiflow.viz import flow_to_mermaid, flow_to_dot
@@ -765,9 +771,17 @@ logged as `log_flow_events_latency_callback_error` so flows continue unharmed.
 ### 8. Testing with FlowTestKit
 
 ```python
+import logging
 import pytest
-from penguiflow.testkit import run_one, assert_node_sequence, simulate_error
+
+from penguiflow import FlowError, Headers, Message, Node, NodePolicy, create, log_flow_events
 from penguiflow.errors import FlowErrorCode
+from penguiflow.testkit import (
+    run_one,
+    assert_node_sequence,
+    simulate_error,
+    get_recorded_events,
+)
 
 @pytest.mark.asyncio
 async def test_retry_succeeds():
@@ -797,6 +811,43 @@ async def test_retry_succeeds():
     assert result == "success"
     assert flaky_func.simulation.attempts == 3  # 1 initial + 2 retries
     assert_node_sequence(message.trace_id, ["flaky"])
+
+    events = get_recorded_events(message.trace_id)
+    assert any(evt.event_type == "node_success" for evt in events)
+
+
+@pytest.mark.asyncio
+async def test_log_flow_events_error_payload() -> None:
+    logger = logging.getLogger("tests.testkit.log_flow_events")
+    logger.setLevel(logging.INFO)
+
+    latency_samples: list[tuple[str, float]] = []
+
+    def capture_latency(event_type: str, latency_ms: float, event) -> None:
+        latency_samples.append((event_type, latency_ms))
+
+    async def always_fails(message: Message, _ctx) -> Message:
+        raise ValueError("boom")
+
+    node = Node(
+        always_fails,
+        name="flaky",
+        policy=NodePolicy(validate="none", max_retries=0),
+    )
+    flow = create(
+        node.to(),
+        middlewares=[log_flow_events(logger, latency_callback=capture_latency)],
+        emit_errors_to_rookery=True,
+    )
+
+    message = Message(payload="demo", headers=Headers(tenant="test"))
+    result = await run_one(flow, message)
+
+    assert isinstance(result, FlowError)
+    events = get_recorded_events(message.trace_id)
+    failed_event = next(evt for evt in events if evt.event_type == "node_failed")
+    assert failed_event.error_payload["code"] == FlowErrorCode.NODE_EXCEPTION.value
+    assert latency_samples and latency_samples[0][0] == "node_error"
 ```
 
 ### 9. React Planner - Basic Usage

--- a/penguiflow/testkit.py
+++ b/penguiflow/testkit.py
@@ -26,6 +26,7 @@ from .types import Headers, Message
 __all__ = [
     "run_one",
     "assert_node_sequence",
+    "get_recorded_events",
     "simulate_error",
     "assert_preserves_message_envelope",
 ]
@@ -264,6 +265,19 @@ def assert_node_sequence(trace_id: str, expected: Sequence[str]) -> None:
             f"  expected: {expected_nodes}\n"
             f"  actual:   {actual_nodes}"
         )
+
+
+def get_recorded_events(trace_id: str) -> tuple[FlowEvent, ...]:
+    """Return the recorded :class:`FlowEvent` history for ``trace_id``.
+
+    The FlowTestKit recorder maintains a bounded cache of trace histories.
+    This helper exposes the immutable snapshot so tests can assert on
+    diagnostics such as ``node_failed`` payloads or retry attempts without
+    touching the private cache directly.
+    """
+
+    events = _TRACE_HISTORY.get(trace_id, [])
+    return tuple(events)
 
 
 class _ErrorSimulation:

--- a/tests/test_testkit.py
+++ b/tests/test_testkit.py
@@ -1,15 +1,18 @@
+import logging
 from typing import Any
 
 import pytest
 
 from penguiflow import (
     FinalAnswer,
+    FlowError,
     FlowErrorCode,
     Headers,
     Message,
     Node,
     NodePolicy,
     create,
+    log_flow_events,
     testkit,
 )
 
@@ -133,4 +136,68 @@ async def test_assert_preserves_message_envelope_rejects_header_mutation() -> No
         )
 
     assert "headers" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_run_one_with_log_flow_events_records_error_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger_name = "tests.testkit.log_flow_events"
+    caplog.set_level(logging.INFO, logger=logger_name)
+
+    latency_events: list[tuple[str, float]] = []
+
+    def capture_latency(event_type: str, latency_ms: float, event: Any) -> None:
+        latency_events.append((event_type, latency_ms))
+
+    async def always_fails(message: Message, _ctx: Any) -> Message:
+        raise ValueError("boom")
+
+    node = Node(
+        always_fails,
+        name="flaky",
+        policy=NodePolicy(validate="none", max_retries=0),
+    )
+    middleware = log_flow_events(
+        logging.getLogger(logger_name), latency_callback=capture_latency
+    )
+    flow = create(
+        node.to(),
+        middlewares=[middleware],
+        emit_errors_to_rookery=True,
+    )
+
+    message = Message(payload="hello", headers=Headers(tenant="acme"))
+
+    result = await testkit.run_one(flow, message)
+
+    assert isinstance(result, FlowError)
+    assert result.code == FlowErrorCode.NODE_EXCEPTION.value
+    assert "flaky" in (result.node_name or "")
+
+    events = testkit.get_recorded_events(message.trace_id)
+    event_types = [event.event_type for event in events]
+    assert "node_error" in event_types
+    assert "node_failed" in event_types
+
+    failed_event = next(event for event in events if event.event_type == "node_failed")
+    payload = failed_event.error_payload
+    assert payload is not None
+    assert payload["code"] == FlowErrorCode.NODE_EXCEPTION.value
+    assert payload["node_name"] == "flaky"
+    assert payload.get("exception_type") == "ValueError"
+
+    failure_logs = [
+        record
+        for record in caplog.records
+        if record.name == logger_name and record.getMessage() == "node_error"
+    ]
+    assert failure_logs, "expected node_error log from log_flow_events"
+    assert not any(
+        record.getMessage() == "node_success" and record.name == logger_name
+        for record in caplog.records
+    )
+
+    assert latency_events and latency_events[0][0] == "node_error"
+    assert latency_events[0][1] > 0.0
 


### PR DESCRIPTION
## Summary
- add `testkit.get_recorded_events` to expose FlowEvent histories for assertions
- extend FlowTestKit coverage to exercise log_flow_events error handling and FlowError payloads
- update manual and llm references with diagnostics guidance that mirrors the new helper

## Testing
- uv run ruff check penguiflow
- uv run mypy penguiflow
- uv run pytest --cov=penguiflow --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e000353f4483229be568bcbb4d0feb