### PR TITLE
Fix planner packaging for optional installation

### DIFF
--- a/penguiflow/__init__.py
+++ b/penguiflow/__init__.py
@@ -105,4 +105,4 @@ __all__ = [
     "TrajectoryStep",
 ]
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "penguiflow"
-version = "2.2.1"
+version = "2.2.2"
 description = "Async agent orchestration primitives."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -42,7 +42,7 @@ penguiflow-admin = "penguiflow.admin:main"
 Homepage = "https://github.com/penguiflow/penguiflow"
 
 [tool.setuptools]
-packages = ["penguiflow", "penguiflow_a2a"]
+packages = { find = { include = ["penguiflow*", "penguiflow_a2a*"] } }
 
 [tool.uv]
 package = true

--- a/uv.lock
+++ b/uv.lock
@@ -936,7 +936,7 @@ wheels = [
 
 [[package]]
 name = "penguiflow"
-version = "2.1.0"
+version = "2.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- ensure the planner subpackage is included in built distributions so optional installs can still import `penguiflow.planner`
- bump the project version to 2.2.2 for the hotfix release

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0c80582fc8322bd39c4a76f7a64c6