### PR TITLE
Add cost tracking to ReactPlanner

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -9231,8 +9231,8 @@ class JSONLLMClient(Protocol):
         *,
         messages: Sequence[Mapping[str, Any]],
         response_format: Mapping[str, Any] | None = None,
-    ) -> str:
-        """Return raw JSON string."""
+    ) -> str | tuple[str, float]:
+        """Return raw JSON string and optional USD cost."""
         ...
 
 # Example: Stub client for testing

--- a/penguiflow/planner/dspy_client.py
+++ b/penguiflow/planner/dspy_client.py
@@ -170,7 +170,7 @@ class DSPyLLMClient:
         *,
         messages: Sequence[Mapping[str, str]],
         response_format: Mapping[str, Any] | None = None,
-    ) -> str:
+    ) -> tuple[str, float]:
         """Generate completion with structured output via DSPy.
 
         Args:
@@ -178,7 +178,7 @@ class DSPyLLMClient:
             response_format: Optional JSON schema for structured output
 
         Returns:
-            JSON string containing the structured response
+            Tuple of JSON string response and cost in USD (DSPy cost is 0.0)
 
         Raises:
             RuntimeError: If all retry attempts fail
@@ -230,9 +230,9 @@ class DSPyLLMClient:
                                     "json_length": len(json_output),
                                 },
                             )
-                            return json_output
+                            return json_output, 0.0
                         elif isinstance(response_obj, dict):
-                            return json.dumps(response_obj)
+                            return json.dumps(response_obj), 0.0
                         else:
                             # DSPy sometimes returns string - normalise to JSON
                             response_str = str(response_obj)
@@ -243,7 +243,7 @@ class DSPyLLMClient:
                             normalised = self._normalise_json(response_str)
                             if normalised is not None:
                                 logger.debug("dspy_json_normalised_success")
-                                return normalised
+                                return normalised, 0.0
                             logger.warning(
                                 "dspy_invalid_json",
                                 extra={"response": response_str[:500]},

--- a/tests/test_react_reflection.py
+++ b/tests/test_react_reflection.py
@@ -41,12 +41,12 @@ class ReflectionStubClient:
         *,
         messages: list[Mapping[str, str]],
         response_format: Mapping[str, object] | None = None,
-    ) -> str:
+    ) -> tuple[str, float]:
         del response_format
         self.calls.append(list(messages))
         if not self._responses:
             raise AssertionError("No stub responses left")
-        return self._responses.pop(0)
+        return self._responses.pop(0), 0.0
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- add a planning-session cost tracker to ReactPlanner and include the snapshot in finish metadata/events
- update LiteLLM and DSPy JSON clients plus tests to return (content, cost) tuples that feed the tracker
- document the new cost tracking feature and add targeted tests for main, reflection, and summarizer call accounting

## Testing
- uv run pytest tests/test_react_planner.py
- uv run pytest tests/test_react_reflection.py

------
https://chatgpt.com/codex/tasks/task_e_68fc220cf20883228ee599913c5d578f