### PR TITLE
feat(playground): add fixed session setup and state-store wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 2.12.5
 
 ### Added
 - Enterprise-grade documentation site (MkDocs) and doc CI checks.
+- Playground fixed-session controls via Setup tab and env config:
+  - `PLAYGROUND_FIXED_SESSION_ID`
+  - `PLAYGROUND_REWRITE_AGUI`
+- Generated project templates now include fixed-session Playground env keys in `.env.example`.
 
 ### Changed
 - Root README rewritten to be a concise “front door” with stable links.
+- `penguiflow dev` now auto-discovers project state-store builders and wires the resulting store into Playground state/task persistence.
+- Memory URL compatibility for discovered legacy builders now relies on `MEMORY_BASE_URL` with internal alias bridging.
 
 ## 2.12.1
 
 Initial entry for the current packaging version. Prior release notes are being backfilled.
-

--- a/docs/cli/dev-command.md
+++ b/docs/cli/dev-command.md
@@ -57,6 +57,17 @@ uv pip install "penguiflow[planner]"
 - Put API keys in `<project_root>/.env` (uncommitted), and rely on `.env` precedence rules:
   - process env wins; `.env` fills only missing values.
 
+## Fixed Session Mode (No Wrapper Needed)
+
+Native Playground now supports fixed session mode directly. You no longer need a custom `playground.py` wrapper to pin sessions.
+
+- Set `.env` values:
+  - `PLAYGROUND_FIXED_SESSION_ID=<your-session-id>`
+  - `PLAYGROUND_REWRITE_AGUI=true|false` (default `false`)
+- These keys are included by default in `.env.example` for projects generated with `penguiflow new`.
+- Or update these at runtime from the Setup tab in the Playground UI.
+- Runtime Setup-tab values take precedence over `.env` values.
+
 ## Failure modes & recovery
 
 - **UI assets missing (`playground_ui/dist`)** (repo checkout): build the UI:

--- a/docs/cli/new-command.md
+++ b/docs/cli/new-command.md
@@ -70,6 +70,9 @@ Choose based on how you will operate the system:
 - Use `--dry-run` in repos to avoid accidental writes.
 - Prefer `react` unless you already know you’re building a pure runtime DAG.
 - Prefer envelope-style messaging and `trace_id` scoping in production systems (see **[Messages & envelopes](../core/messages-and-envelopes.md)**).
+- Generated templates include Playground fixed-session env keys in `.env.example`:
+  - `PLAYGROUND_FIXED_SESSION_ID`
+  - `PLAYGROUND_REWRITE_AGUI`
 
 ## Runnable example (typical usage)
 

--- a/penguiflow/cli/dev.py
+++ b/penguiflow/cli/dev.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import importlib
+import logging
 import os
+import sys
 import webbrowser
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple, cast
 
 import uvicorn
 
 from .playground import PlaygroundError, create_playground_app
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _load_env_file(env_path: Path) -> dict[str, str]:
@@ -57,6 +64,130 @@ def _ensure_ui_assets(base_dir: Path) -> None:
         )
 
 
+_MEMORY_BASE_URL_ALIASES = ("PLATFORM_URL",)
+
+
+@contextmanager
+def _memory_base_url_compat_env() -> Iterator[None]:
+    """Temporary compatibility shim for legacy project state-store builders.
+
+    `penguiflow dev` relies on `MEMORY_BASE_URL` as the user-facing setting.
+    During builder invocation only, mirror this value to legacy alias keys when
+    those keys are absent.
+    """
+    memory_url = os.getenv("MEMORY_BASE_URL")
+    inserted_keys: list[str] = []
+
+    if memory_url:
+        for key in _MEMORY_BASE_URL_ALIASES:
+            if key in os.environ:
+                continue
+            inserted_keys.append(key)
+            os.environ[key] = memory_url
+
+    try:
+        yield
+    finally:
+        for key in inserted_keys:
+            os.environ.pop(key, None)
+
+
+@contextmanager
+def _memory_base_url_compat_builder_patch(module: Any) -> Iterator[None]:
+    """Patch legacy env helpers to honor ``MEMORY_BASE_URL`` aliasing.
+
+    Some generated builders call a local ``from_env_or_dotenv`` helper that can
+    ignore process env values when running locally. This patch ensures alias
+    keys resolve from ``MEMORY_BASE_URL`` as a fallback during factory calls.
+    """
+    original = getattr(module, "from_env_or_dotenv", None)
+    memory_url = os.getenv("MEMORY_BASE_URL")
+    if not callable(original) or not memory_url:
+        yield
+        return
+    original_fn = cast(Callable[[str, str], str], original)
+
+    def _patched(env_var_name: str, default: str) -> str:
+        if env_var_name in _MEMORY_BASE_URL_ALIASES:
+            # Prefer process env prepared by `run_dev` over any cwd-scoped
+            # dotenv reads inside legacy helpers.
+            env_value = os.getenv(env_var_name)
+            if env_value:
+                return env_value
+            return memory_url
+        value = original_fn(env_var_name, default)
+        return value
+
+    module.from_env_or_dotenv = _patched
+    try:
+        yield
+    finally:
+        module.from_env_or_dotenv = original_fn
+
+
+def _load_project_state_store(project_root: Path) -> Any | None:
+    """Try to build a project-provided state store from env.
+
+    Lookup order:
+    1) agentiv.state_store_enhanced.build_agentiv_enhanced_state_store_from_env
+    2) agentiv.state_store.build_agentiv_state_store_from_env
+    """
+    src_dir = project_root / "src"
+    search_root = src_dir if src_dir.exists() else project_root
+    root_str = str(search_root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+
+    candidates = [
+        ("agentiv.state_store_enhanced", "build_agentiv_enhanced_state_store_from_env"),
+        ("agentiv.state_store", "build_agentiv_state_store_from_env"),
+    ]
+
+    for module_name, factory_name in candidates:
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError:
+            continue
+        except Exception as exc:
+            _LOGGER.debug("state_store_module_import_failed", exc_info=exc)
+            continue
+        factory = getattr(module, factory_name, None)
+        if not callable(factory):
+            continue
+        try:
+            with _memory_base_url_compat_env(), _memory_base_url_compat_builder_patch(module):
+                store = factory()
+            _LOGGER.info(
+                "playground_state_store_loaded",
+                extra={"module": module_name, "factory": factory_name, "type": type(store).__name__},
+            )
+            return store
+        except Exception as exc:
+            _LOGGER.debug(
+                "state_store_factory_failed",
+                extra={"module": module_name, "factory": factory_name},
+                exc_info=exc,
+            )
+            continue
+    return None
+
+
+def _describe_state_store(store: Any) -> tuple[str, str | None]:
+    """Return store type and best-effort base URL for diagnostics."""
+    store_type = type(store).__name__
+    # Common pattern: httpx.AsyncClient stored as `_client`.
+    client = getattr(store, "_client", None)
+    base_url = getattr(client, "base_url", None)
+    if base_url is not None:
+        return store_type, str(base_url)
+    # Fallback patterns used by custom stores.
+    for attr in ("base_url", "_base_url", "url", "_url"):
+        value = getattr(store, attr, None)
+        if value:
+            return store_type, str(value)
+    return store_type, None
+
+
 def run_dev(*, project_root: Path, host: str, port: int, open_browser: bool) -> DevServerInfo:
     """Create the playground app and run uvicorn."""
 
@@ -70,8 +201,17 @@ def run_dev(*, project_root: Path, host: str, port: int, open_browser: bool) -> 
         if key not in os.environ:  # Don't override existing env vars
             os.environ[key] = value
 
+    state_store = _load_project_state_store(project_root)
+    if state_store is None:
+        print("  State: in-memory store (no project state_store loaded)")
+    else:
+        store_type, store_url = _describe_state_store(state_store)
+        print(f"  State: project store ({store_type})")
+        if store_url:
+            print(f"  State URL: {store_url}")
+
     try:
-        app = create_playground_app(project_root=project_root)
+        app = create_playground_app(project_root=project_root, state_store=state_store)
     except PlaygroundError as exc:
         raise CLIError(str(exc)) from exc
 

--- a/penguiflow/cli/playground.py
+++ b/penguiflow/cli/playground.py
@@ -7,13 +7,16 @@ import importlib
 import inspect
 import json
 import logging
+import os
 import secrets
 import sys
+import threading
 from collections.abc import AsyncIterator, Callable, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import parse_qsl, urlencode
 
 from fastapi import FastAPI, Header, HTTPException, Request
 from fastapi.responses import FileResponse, Response, StreamingResponse
@@ -223,6 +226,319 @@ class AguiResumeRequest(BaseModel):
     tool_context: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(extra="ignore")
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if not normalized:
+        return default
+    return normalized in {"1", "true", "yes", "on"}
+
+
+def _normalise_optional_session_id(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+class SetupStateResponse(BaseModel):
+    fixed_session_id: str | None
+    rewrite_agui: bool
+    fixed_session_source: Literal["runtime", "env", "none"]
+    rewrite_agui_source: Literal["runtime", "env"]
+    runtime_fixed_session_id: str | None
+    runtime_rewrite_agui: bool | None
+    env_fixed_session_id: str | None
+    env_rewrite_agui: bool
+
+
+class SetupUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    fixed_session_id: str | None = None
+    rewrite_agui: bool | None = None
+
+
+class PlaygroundSetupState:
+    """Mutable runtime setup for fixed-session Playground behavior."""
+
+    _OVERRIDE_HEADER_NAMES: tuple[bytes, ...] = (
+        b"x-playground-fixed-session-id",
+        b"x-fixed-session-id",
+    )
+
+    def __init__(
+        self,
+        *,
+        env_fixed_session_id: str | None = None,
+        env_rewrite_agui: bool = False,
+    ) -> None:
+        self._env_fixed_session_id = _normalise_optional_session_id(env_fixed_session_id)
+        self._env_rewrite_agui = bool(env_rewrite_agui)
+        self._runtime_fixed_session_id: str | None = None
+        self._runtime_rewrite_agui: bool | None = None
+        self._lock = threading.RLock()
+
+    @classmethod
+    def from_env(cls) -> PlaygroundSetupState:
+        return cls(
+            env_fixed_session_id=os.getenv("PLAYGROUND_FIXED_SESSION_ID"),
+            env_rewrite_agui=_env_flag("PLAYGROUND_REWRITE_AGUI", default=False),
+        )
+
+    @staticmethod
+    def _extract_override_session(headers: list[tuple[bytes, bytes]] | None) -> str | None:
+        if not headers:
+            return None
+        for name, value in headers:
+            lowered = name.lower()
+            if lowered not in PlaygroundSetupState._OVERRIDE_HEADER_NAMES:
+                continue
+            raw = value.decode("utf-8", errors="ignore")
+            normalized = _normalise_optional_session_id(raw)
+            if normalized:
+                return normalized
+        return None
+
+    def effective_fixed_session_id(self, headers: list[tuple[bytes, bytes]] | None = None) -> str | None:
+        with self._lock:
+            if self._runtime_fixed_session_id:
+                return self._runtime_fixed_session_id
+            request_override = self._extract_override_session(headers)
+            if request_override:
+                return request_override
+            return self._env_fixed_session_id
+
+    def effective_rewrite_agui(self) -> bool:
+        with self._lock:
+            if self._runtime_rewrite_agui is not None:
+                return self._runtime_rewrite_agui
+            return self._env_rewrite_agui
+
+    def update_runtime(self, payload: SetupUpdateRequest) -> SetupStateResponse:
+        with self._lock:
+            fields_set = payload.model_fields_set
+            if "fixed_session_id" in fields_set:
+                self._runtime_fixed_session_id = _normalise_optional_session_id(payload.fixed_session_id)
+            if "rewrite_agui" in fields_set:
+                self._runtime_rewrite_agui = payload.rewrite_agui
+            return self.snapshot()
+
+    def snapshot(self) -> SetupStateResponse:
+        with self._lock:
+            if self._runtime_fixed_session_id:
+                fixed_source: Literal["runtime", "env", "none"] = "runtime"
+                fixed_session_id = self._runtime_fixed_session_id
+            elif self._env_fixed_session_id:
+                fixed_source = "env"
+                fixed_session_id = self._env_fixed_session_id
+            else:
+                fixed_source = "none"
+                fixed_session_id = None
+
+            if self._runtime_rewrite_agui is None:
+                rewrite_source: Literal["runtime", "env"] = "env"
+                rewrite_agui = self._env_rewrite_agui
+            else:
+                rewrite_source = "runtime"
+                rewrite_agui = self._runtime_rewrite_agui
+
+            return SetupStateResponse(
+                fixed_session_id=fixed_session_id,
+                rewrite_agui=rewrite_agui,
+                fixed_session_source=fixed_source,
+                rewrite_agui_source=rewrite_source,
+                runtime_fixed_session_id=self._runtime_fixed_session_id,
+                runtime_rewrite_agui=self._runtime_rewrite_agui,
+                env_fixed_session_id=self._env_fixed_session_id,
+                env_rewrite_agui=self._env_rewrite_agui,
+            )
+
+
+class FixedSessionRewriteMiddleware:
+    """Rewrite session values in query/header/body when a fixed session is active."""
+
+    _JSON_PATHS = {"/chat", "/agui/agent", "/agui/resume"}
+
+    def __init__(self, app: Any, setup_state: PlaygroundSetupState) -> None:
+        self.app = app
+        self.setup_state = setup_state
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        fixed_session_id = self.setup_state.effective_fixed_session_id(scope.get("headers"))
+        if not fixed_session_id:
+            await self.app(scope, receive, send)
+            return
+
+        method = str(scope.get("method", "")).upper()
+        path = str(scope.get("path", ""))
+        normalized_path = path.rstrip("/") or "/"
+
+        rewritten_scope = dict(scope)
+        rewritten_scope, _ = self._rewrite_query_session(rewritten_scope, fixed_session_id)
+        rewritten_scope, _ = self._rewrite_session_header(rewritten_scope, fixed_session_id)
+
+        request_receive = receive
+        if method in {"POST", "PUT", "PATCH"} and normalized_path in self._JSON_PATHS:
+            body = await self._read_body(receive)
+            payload = self._parse_json_body(body)
+            if payload is None:
+                request_receive = self._build_receive(body, receive)
+            else:
+                rewrite_agui = self.setup_state.effective_rewrite_agui()
+                payload = self._rewrite_json_payload(
+                    normalized_path,
+                    payload,
+                    fixed_session_id,
+                    rewrite_agui=rewrite_agui,
+                )
+                encoded = json.dumps(payload).encode("utf-8")
+                request_receive = self._build_receive(encoded, receive)
+                rewritten_scope = self._rewrite_content_length(rewritten_scope, len(encoded))
+
+        await self.app(rewritten_scope, request_receive, send)
+
+    @staticmethod
+    def _rewrite_query_session(scope: dict[str, Any], fixed_session_id: str) -> tuple[dict[str, Any], str | None]:
+        raw_qs = scope.get("query_string", b"")
+        if not raw_qs:
+            return scope, None
+
+        params = parse_qsl(raw_qs.decode("utf-8"), keep_blank_values=True)
+        rewritten = False
+        session_from: str | None = None
+        out: list[tuple[str, str]] = []
+
+        for key, value in params:
+            if key == "session_id" and value != fixed_session_id:
+                if value and session_from is None:
+                    session_from = value
+                value = fixed_session_id
+                rewritten = True
+            out.append((key, value))
+
+        if not rewritten:
+            return scope, session_from
+
+        new_scope = dict(scope)
+        new_scope["query_string"] = urlencode(out).encode("utf-8")
+        return new_scope, session_from
+
+    @staticmethod
+    def _rewrite_session_header(scope: dict[str, Any], fixed_session_id: str) -> tuple[dict[str, Any], str | None]:
+        headers = list(scope.get("headers", []))
+        rewritten = False
+        session_from: str | None = None
+        out: list[tuple[bytes, bytes]] = []
+
+        for name, value in headers:
+            if name.lower() == b"x-session-id":
+                current = value.decode("utf-8", errors="ignore")
+                if current and current != fixed_session_id:
+                    if session_from is None:
+                        session_from = current
+                    value = fixed_session_id.encode("utf-8")
+                    rewritten = True
+            out.append((name, value))
+
+        if not rewritten:
+            return scope, session_from
+
+        new_scope = dict(scope)
+        new_scope["headers"] = out
+        return new_scope, session_from
+
+    @staticmethod
+    def _rewrite_content_length(scope: dict[str, Any], body_len: int) -> dict[str, Any]:
+        headers = list(scope.get("headers", []))
+        out: list[tuple[bytes, bytes]] = []
+        replaced = False
+        for name, value in headers:
+            if name.lower() == b"content-length":
+                out.append((name, str(body_len).encode("ascii")))
+                replaced = True
+            else:
+                out.append((name, value))
+        if not replaced:
+            out.append((b"content-length", str(body_len).encode("ascii")))
+        new_scope = dict(scope)
+        new_scope["headers"] = out
+        return new_scope
+
+    @staticmethod
+    def _rewrite_json_payload(
+        normalized_path: str,
+        payload: dict[str, Any],
+        fixed_session_id: str,
+        *,
+        rewrite_agui: bool,
+    ) -> dict[str, Any]:
+        if normalized_path == "/chat":
+            payload["session_id"] = fixed_session_id
+            tool_context = payload.get("tool_context")
+            if tool_context is None:
+                tool_context = {}
+                payload["tool_context"] = tool_context
+            if isinstance(tool_context, dict):
+                tool_context["session_id"] = fixed_session_id
+            return payload
+
+        if normalized_path in {"/agui/agent", "/agui/resume"} and rewrite_agui:
+            if "thread_id" in payload:
+                payload["thread_id"] = fixed_session_id
+            if "threadId" in payload:
+                payload["threadId"] = fixed_session_id
+            if "thread_id" not in payload and "threadId" not in payload:
+                if normalized_path == "/agui/resume":
+                    payload["thread_id"] = fixed_session_id
+                else:
+                    payload["threadId"] = fixed_session_id
+        return payload
+
+    @staticmethod
+    async def _read_body(receive: Any) -> bytes:
+        chunks: list[bytes] = []
+        more = True
+        while more:
+            message = await receive()
+            if message.get("type") == "http.disconnect":
+                break
+            if message.get("type") != "http.request":
+                continue
+            chunks.append(message.get("body", b""))
+            more = bool(message.get("more_body", False))
+        return b"".join(chunks)
+
+    @staticmethod
+    def _build_receive(body: bytes, original_receive: Any) -> Any:
+        sent = False
+
+        async def _receive() -> dict[str, Any]:
+            nonlocal sent
+            if sent:
+                return await original_receive()
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        return _receive
+
+    @staticmethod
+    def _parse_json_body(body: bytes) -> dict[str, Any] | None:
+        if not body:
+            return {}
+        try:
+            parsed = json.loads(body.decode("utf-8"))
+        except Exception:
+            return None
+        return parsed if isinstance(parsed, dict) else None
 
 
 def _parse_context_arg(raw: str | None) -> dict[str, Any]:
@@ -829,6 +1145,7 @@ def create_playground_app(
     ui_dir = Path(__file__).resolve().parent / "playground_ui" / "dist"
     spec_payload, parsed_spec = _load_spec_payload(Path(project_root or ".").resolve())
     meta_payload = _meta_from_spec(parsed_spec)
+    setup_state = PlaygroundSetupState.from_env()
 
     # Determine session_store first so we can create SessionManager before load_agent.
     # This allows the orchestrator to share the same SessionManager for background task visibility.
@@ -881,6 +1198,7 @@ def create_playground_app(
                 await agent_wrapper.shutdown()
 
     app = FastAPI(title="PenguiFlow Playground", version="0.1.0", lifespan=_lifespan)
+    app.add_middleware(FixedSessionRewriteMiddleware, setup_state)  # type: ignore[arg-type]
     proactive_setup: Callable[[Any], None] | None = None
 
     # Optional: enable platform task-management meta-tools when a planner factory is available.
@@ -1184,6 +1502,14 @@ def create_playground_app(
     @app.get("/ui/meta", response_model=MetaPayload)
     async def ui_meta() -> MetaPayload:
         return meta_payload
+
+    @app.get("/ui/setup", response_model=SetupStateResponse)
+    async def ui_setup() -> SetupStateResponse:
+        return setup_state.snapshot()
+
+    @app.put("/ui/setup", response_model=SetupStateResponse)
+    async def ui_setup_update(payload: SetupUpdateRequest) -> SetupStateResponse:
+        return setup_state.update_runtime(payload)
 
     @app.get("/ui/components", response_model=ComponentRegistryPayload)
     async def ui_components() -> ComponentRegistryPayload:
@@ -2141,6 +2467,7 @@ def create_playground_app(
     app.state.agent_wrapper = agent_wrapper
     app.state.state_store = store
     app.state.broker = broker
+    app.state.setup_state = setup_state
     return app
 
 

--- a/penguiflow/cli/playground_ui/src/App.svelte
+++ b/penguiflow/cli/playground_ui/src/App.svelte
@@ -5,6 +5,7 @@
   } from "$lib/stores";
   import {
     loadMeta,
+    loadPlaygroundSetup,
     loadSpec,
     loadComponentRegistry,
     fetchTrajectory,
@@ -26,6 +27,8 @@
   import { MobileHeader, MobileBottomPanel } from "$lib/components/features/mobile";
   import { ChatCard } from "$lib/components/features/chat";
   import type { ChatMessage, PendingInteraction } from '$lib/types';
+
+  const SETUP_STORAGE_KEY = 'penguiflow.playground.setup.v1';
 
   const stores = initStores();
   const {
@@ -89,10 +92,11 @@
   });
 
   const initializeApp = async () => {
-    const [metaData, specData, componentData] = await Promise.all([
+    const [metaData, specData, componentData, setupData] = await Promise.all([
       loadMeta(),
       loadSpec(),
-      loadComponentRegistry()
+      loadComponentRegistry(),
+      loadPlaygroundSetup()
     ]);
     if (metaData) {
       agentStore.setFromResponse(metaData);
@@ -103,7 +107,45 @@
     if (componentData) {
       componentRegistryStore.setFromPayload(componentData);
     }
+    if (setupData) {
+      setupStore.applyBackendSetup(setupData);
+      if (setupData.fixed_session_id) {
+        sessionStore.sessionId = setupData.fixed_session_id;
+      }
+    }
   };
+
+  onMount(() => {
+    try {
+      const raw = window.localStorage.getItem(SETUP_STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        if (typeof parsed.useAgui === 'boolean') {
+          setupStore.useAgui = parsed.useAgui;
+        }
+        if (typeof parsed.fixedSessionId === 'string') {
+          setupStore.fixedSessionId = parsed.fixedSessionId;
+        }
+        if (typeof parsed.rewriteAguiRequests === 'boolean') {
+          setupStore.rewriteAguiRequests = parsed.rewriteAguiRequests;
+        }
+      }
+    } catch {
+      // Ignore malformed local storage data.
+    }
+  });
+
+  $effect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const payload = {
+      useAgui: setupStore.useAgui,
+      fixedSessionId: setupStore.fixedSessionId,
+      rewriteAguiRequests: setupStore.rewriteAguiRequests
+    };
+    window.localStorage.setItem(SETUP_STORAGE_KEY, JSON.stringify(payload));
+  });
 
   const sendChat = () => {
     const query = chatStore.input.trim();

--- a/penguiflow/cli/playground_ui/src/lib/components/features/setup/SetupTab.svelte
+++ b/penguiflow/cli/playground_ui/src/lib/components/features/setup/SetupTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { readable } from 'svelte/store';
   import { ErrorList } from '$lib/components/composites';
+  import { savePlaygroundSetup } from '$lib/services';
   import { getEventsStore, getInteractionsStore, getSessionStore, getSetupStore, getTrajectoryStore } from '$lib/stores';
   import { MessageList, StateDebugger, setAGUIContext, type AGUIStore } from '$lib/agui';
   import SetupField from './SetupField.svelte';
@@ -47,6 +48,29 @@
   const trajectoryStore = getTrajectoryStore();
   const eventsStore = getEventsStore();
   const interactionsStore = getInteractionsStore();
+  let isSavingSetup = $state(false);
+  let setupSaveMessage = $state<string | null>(null);
+
+  const saveRuntimeSetup = async () => {
+    setupStore.clearError();
+    setupSaveMessage = null;
+    isSavingSetup = true;
+    const fixedSessionId = setupStore.fixedSessionId.trim();
+    const updated = await savePlaygroundSetup({
+      fixed_session_id: fixedSessionId ? fixedSessionId : null,
+      rewrite_agui: setupStore.rewriteAguiRequests
+    });
+    isSavingSetup = false;
+    if (!updated) {
+      setupStore.error = 'Failed to save Playground setup.';
+      return;
+    }
+    setupStore.applyBackendSetup(updated);
+    setupSaveMessage = 'Playground setup saved.';
+    if (updated.fixed_session_id) {
+      sessionStore.sessionId = updated.fixed_session_id;
+    }
+  };
 
   setAGUIContext(previewStore);
 </script>
@@ -68,6 +92,29 @@
           New
         </button>
       </div>
+    </SetupField>
+
+    <SetupField
+      label="Fixed Session ID (Optional)"
+      hint="Pins query/header/body session IDs in the backend. Leave blank for default dynamic sessions."
+      full
+    >
+      <input class="setup-input" bind:value={setupStore.fixedSessionId} placeholder="e.g. test-session-001" />
+      <div class="action-row">
+        <button class="ghost-btn small" onclick={saveRuntimeSetup} disabled={isSavingSetup}>
+          {isSavingSetup ? 'Saving...' : 'Save Playground Setup'}
+        </button>
+      </div>
+      {#if setupStore.backendSetup}
+        <div class="setup-note">
+          Effective session:
+          <code>{setupStore.backendSetup.fixed_session_id ?? 'dynamic'}</code>
+          ({setupStore.backendSetup.fixed_session_source})
+        </div>
+      {/if}
+      {#if setupSaveMessage}
+        <div class="setup-note">{setupSaveMessage}</div>
+      {/if}
     </SetupField>
 
     <SetupField label="Tenant ID">
@@ -100,6 +147,17 @@
         bind:value={setupStore.llmContextRaw}
         placeholder={'{}'}
       ></textarea>
+    </SetupField>
+
+    <SetupField
+      label="AG-UI Thread Rewrite"
+      hint="When enabled, fixed session mode rewrites AG-UI thread_id/threadId for /agui requests."
+      full
+    >
+      <label class="toggle-row">
+        <input class="toggle-input" type="checkbox" bind:checked={setupStore.rewriteAguiRequests} />
+        <span>Rewrite AG-UI thread IDs to fixed session</span>
+      </label>
     </SetupField>
 
     <SetupField
@@ -207,6 +265,18 @@
   .agui-preview-title {
     font-size: 12px;
     font-weight: 600;
+    color: var(--color-text-secondary, #3c3a36);
+  }
+
+  .action-row {
+    margin-top: 8px;
+    display: flex;
+    gap: 8px;
+  }
+
+  .setup-note {
+    margin-top: 8px;
+    font-size: 11px;
     color: var(--color-text-secondary, #3c3a36);
   }
 

--- a/penguiflow/cli/playground_ui/src/lib/services/api.ts
+++ b/penguiflow/cli/playground_ui/src/lib/services/api.ts
@@ -1,5 +1,6 @@
 import type {
   MetaResponse,
+  PlaygroundSetupState,
   SpecData,
   ValidationResult,
   TrajectoryPayload,
@@ -62,6 +63,30 @@ export async function loadMeta(): Promise<MetaResponse | null> {
   const result = await fetchWithErrorHandling<MetaResponse>(`${BASE_URL}/ui/meta`);
   if (!result.ok) {
     console.error('meta load failed', result.error);
+    return null;
+  }
+  return result.data;
+}
+
+export async function loadPlaygroundSetup(): Promise<PlaygroundSetupState | null> {
+  const result = await fetchWithErrorHandling<PlaygroundSetupState>(`${BASE_URL}/ui/setup`);
+  if (!result.ok) {
+    console.error('setup load failed', result.error);
+    return null;
+  }
+  return result.data;
+}
+
+export async function savePlaygroundSetup(
+  payload: Partial<Pick<PlaygroundSetupState, 'fixed_session_id' | 'rewrite_agui'>>
+): Promise<PlaygroundSetupState | null> {
+  const result = await fetchWithErrorHandling<PlaygroundSetupState>(`${BASE_URL}/ui/setup`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!result.ok) {
+    console.error('setup save failed', result.error);
     return null;
   }
   return result.data;

--- a/penguiflow/cli/playground_ui/src/lib/stores/features/setup.svelte.ts
+++ b/penguiflow/cli/playground_ui/src/lib/stores/features/setup.svelte.ts
@@ -1,4 +1,5 @@
 import { getContext, setContext } from 'svelte';
+import type { PlaygroundSetupState } from '$lib/types';
 import { parseJsonObject } from '$lib/utils';
 
 const SETUP_STORE_KEY = Symbol('setup-store');
@@ -13,8 +14,12 @@ export interface SetupStore {
   userId: string;
   toolContextRaw: string;
   llmContextRaw: string;
+  fixedSessionId: string;
+  rewriteAguiRequests: boolean;
+  backendSetup: PlaygroundSetupState | null;
   error: string | null;
   useAgui: boolean;
+  applyBackendSetup(setup: PlaygroundSetupState): void;
   parseContexts(): SetupContext | null;
   clearError(): void;
   reset(): void;
@@ -25,6 +30,9 @@ export function createSetupStore(): SetupStore {
   let userId = $state('playground-user');
   let toolContextRaw = $state('{}');
   let llmContextRaw = $state('{}');
+  let fixedSessionId = $state('');
+  let rewriteAguiRequests = $state(false);
+  let backendSetup = $state<PlaygroundSetupState | null>(null);
   let error = $state<string | null>(null);
   let useAgui = $state(false);
 
@@ -41,11 +49,26 @@ export function createSetupStore(): SetupStore {
     get llmContextRaw() { return llmContextRaw; },
     set llmContextRaw(v: string) { llmContextRaw = v; },
 
+    get fixedSessionId() { return fixedSessionId; },
+    set fixedSessionId(v: string) { fixedSessionId = v; },
+
+    get rewriteAguiRequests() { return rewriteAguiRequests; },
+    set rewriteAguiRequests(v: boolean) { rewriteAguiRequests = v; },
+
+    get backendSetup() { return backendSetup; },
+    set backendSetup(v: PlaygroundSetupState | null) { backendSetup = v; },
+
     get error() { return error; },
     set error(v: string | null) { error = v; },
 
     get useAgui() { return useAgui; },
     set useAgui(v: boolean) { useAgui = v; },
+
+    applyBackendSetup(setup: PlaygroundSetupState) {
+      backendSetup = setup;
+      fixedSessionId = setup.fixed_session_id ?? '';
+      rewriteAguiRequests = setup.rewrite_agui;
+    },
 
     /**
      * Parse and validate contexts
@@ -77,6 +100,9 @@ export function createSetupStore(): SetupStore {
       userId = 'playground-user';
       toolContextRaw = '{}';
       llmContextRaw = '{}';
+      fixedSessionId = '';
+      rewriteAguiRequests = false;
+      backendSetup = null;
       error = null;
       useAgui = false;
     }

--- a/penguiflow/cli/playground_ui/src/lib/types/meta.ts
+++ b/penguiflow/cli/playground_ui/src/lib/types/meta.ts
@@ -38,3 +38,14 @@ export interface MetaResponse {
   tools?: Array<{ name: string; description: string; tags?: string[] }>;
   flows?: unknown[];
 }
+
+export interface PlaygroundSetupState {
+  fixed_session_id: string | null;
+  rewrite_agui: boolean;
+  fixed_session_source: 'runtime' | 'env' | 'none';
+  rewrite_agui_source: 'runtime' | 'env';
+  runtime_fixed_session_id: string | null;
+  runtime_rewrite_agui: boolean | null;
+  env_fixed_session_id: string | null;
+  env_rewrite_agui: boolean;
+}

--- a/penguiflow/cli/playground_ui/tests/unit/services/api.test.ts
+++ b/penguiflow/cli/playground_ui/tests/unit/services/api.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   loadMeta,
+  loadPlaygroundSetup,
+  savePlaygroundSetup,
   loadSpec,
   validateSpec,
   generateProject,
@@ -47,6 +49,59 @@ describe('api service', () => {
       const result = await loadMeta();
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('playground setup APIs', () => {
+    it('loads setup successfully', async () => {
+      const mockSetup = {
+        fixed_session_id: 'session-1',
+        rewrite_agui: false,
+        fixed_session_source: 'env',
+        rewrite_agui_source: 'env',
+        runtime_fixed_session_id: null,
+        runtime_rewrite_agui: null,
+        env_fixed_session_id: 'session-1',
+        env_rewrite_agui: false
+      };
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockSetup)
+      });
+
+      const result = await loadPlaygroundSetup();
+      expect(fetch).toHaveBeenCalledWith('/ui/setup');
+      expect(result).toEqual(mockSetup);
+    });
+
+    it('saves setup successfully', async () => {
+      const mockSetup = {
+        fixed_session_id: 'session-2',
+        rewrite_agui: true,
+        fixed_session_source: 'runtime',
+        rewrite_agui_source: 'runtime',
+        runtime_fixed_session_id: 'session-2',
+        runtime_rewrite_agui: true,
+        env_fixed_session_id: null,
+        env_rewrite_agui: false
+      };
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockSetup)
+      });
+
+      const result = await savePlaygroundSetup({
+        fixed_session_id: 'session-2',
+        rewrite_agui: true
+      });
+      expect(fetch).toHaveBeenCalledWith('/ui/setup', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fixed_session_id: 'session-2', rewrite_agui: true })
+      });
+      expect(result).toEqual(mockSetup);
     });
   });
 

--- a/penguiflow/cli/playground_ui/tests/unit/stores/setup.test.ts
+++ b/penguiflow/cli/playground_ui/tests/unit/stores/setup.test.ts
@@ -32,6 +32,15 @@ describe('setupStore', () => {
     it('defaults to SSE protocol', () => {
       expect(setupStore.useAgui).toBe(false);
     });
+
+    it('has no fixed session override by default', () => {
+      expect(setupStore.fixedSessionId).toBe('');
+      expect(setupStore.backendSetup).toBeNull();
+    });
+
+    it('defaults AG-UI rewrite toggle to false', () => {
+      expect(setupStore.rewriteAguiRequests).toBe(false);
+    });
   });
 
   describe('setters', () => {
@@ -58,6 +67,35 @@ describe('setupStore', () => {
     it('sets AG-UI toggle', () => {
       setupStore.useAgui = true;
       expect(setupStore.useAgui).toBe(true);
+    });
+
+    it('sets fixed session id', () => {
+      setupStore.fixedSessionId = 'fixed-session';
+      expect(setupStore.fixedSessionId).toBe('fixed-session');
+    });
+
+    it('sets AG-UI rewrite behavior', () => {
+      setupStore.rewriteAguiRequests = true;
+      expect(setupStore.rewriteAguiRequests).toBe(true);
+    });
+  });
+
+  describe('applyBackendSetup', () => {
+    it('applies effective setup payload', () => {
+      setupStore.applyBackendSetup({
+        fixed_session_id: 'env-session',
+        rewrite_agui: true,
+        fixed_session_source: 'env',
+        rewrite_agui_source: 'env',
+        runtime_fixed_session_id: null,
+        runtime_rewrite_agui: null,
+        env_fixed_session_id: 'env-session',
+        env_rewrite_agui: true
+      });
+
+      expect(setupStore.fixedSessionId).toBe('env-session');
+      expect(setupStore.rewriteAguiRequests).toBe(true);
+      expect(setupStore.backendSetup?.fixed_session_source).toBe('env');
     });
   });
 
@@ -124,6 +162,8 @@ describe('setupStore', () => {
       setupStore.userId = 'custom-user';
       setupStore.toolContextRaw = '{"key": "value"}';
       setupStore.llmContextRaw = '{"model": "test"}';
+      setupStore.fixedSessionId = 'fixed-abc';
+      setupStore.rewriteAguiRequests = true;
       setupStore.error = 'Some error';
       setupStore.useAgui = true;
       
@@ -133,6 +173,9 @@ describe('setupStore', () => {
       expect(setupStore.userId).toBe('playground-user');
       expect(setupStore.toolContextRaw).toBe('{}');
       expect(setupStore.llmContextRaw).toBe('{}');
+      expect(setupStore.fixedSessionId).toBe('');
+      expect(setupStore.rewriteAguiRequests).toBe(false);
+      expect(setupStore.backendSetup).toBeNull();
       expect(setupStore.error).toBeNull();
       expect(setupStore.useAgui).toBe(false);
     });

--- a/penguiflow/templates/new/analyst/.env.example
+++ b/penguiflow/templates/new/analyst/.env.example
@@ -1,3 +1,7 @@
 MEMORY_BASE_URL=http://localhost:8000
 ANALYST_BASE_URL=http://localhost:9200
 LLM_MODEL=stub-llm
+
+# Playground fixed-session options (optional)
+PLAYGROUND_FIXED_SESSION_ID=
+PLAYGROUND_REWRITE_AGUI=false

--- a/penguiflow/templates/new/controller/.env.example
+++ b/penguiflow/templates/new/controller/.env.example
@@ -1,3 +1,7 @@
 MEMORY_BASE_URL=http://localhost:8000
 LLM_MODEL=stub-llm
 MAX_HOPS=5
+
+# Playground fixed-session options (optional)
+PLAYGROUND_FIXED_SESSION_ID=
+PLAYGROUND_REWRITE_AGUI=false

--- a/penguiflow/templates/new/enterprise/.env.example
+++ b/penguiflow/templates/new/enterprise/.env.example
@@ -1,2 +1,6 @@
 MEMORY_BASE_URL=http://localhost:8000
 LLM_MODEL=stub-llm
+
+# Playground fixed-session options (optional)
+PLAYGROUND_FIXED_SESSION_ID=
+PLAYGROUND_REWRITE_AGUI=false

--- a/penguiflow/templates/new/flow/.env.example
+++ b/penguiflow/templates/new/flow/.env.example
@@ -3,3 +3,7 @@
 
 # Memory service endpoint (if memory_enabled)
 # MEMORY_BASE_URL=http://localhost:8000
+
+# Playground fixed-session options (optional)
+PLAYGROUND_FIXED_SESSION_ID=
+PLAYGROUND_REWRITE_AGUI=false

--- a/penguiflow/templates/new/minimal/.env.example
+++ b/penguiflow/templates/new/minimal/.env.example
@@ -1,2 +1,6 @@
 MEMORY_BASE_URL=http://localhost:8000
 LLM_MODEL=stub-llm
+
+# Playground fixed-session options (optional)
+PLAYGROUND_FIXED_SESSION_ID=
+PLAYGROUND_REWRITE_AGUI=false

--- a/penguiflow/templates/new/parallel/.env.example
+++ b/penguiflow/templates/new/parallel/.env.example
@@ -1,2 +1,6 @@
 MEMORY_BASE_URL=http://localhost:8000
 LLM_MODEL=stub-llm
+
+# Playground fixed-session options (optional)
+PLAYGROUND_FIXED_SESSION_ID=
+PLAYGROUND_REWRITE_AGUI=false

--- a/penguiflow/templates/new/rag_server/.env.example
+++ b/penguiflow/templates/new/rag_server/.env.example
@@ -1,3 +1,7 @@
 MEMORY_BASE_URL=http://localhost:8000
 RAG_SERVER_BASE_URL=http://localhost:9000
 LLM_MODEL=stub-llm
+
+# Playground fixed-session options (optional)
+PLAYGROUND_FIXED_SESSION_ID=
+PLAYGROUND_REWRITE_AGUI=false

--- a/penguiflow/templates/new/react/.env.example
+++ b/penguiflow/templates/new/react/.env.example
@@ -1,2 +1,6 @@
 MEMORY_BASE_URL=http://localhost:8000
 LLM_MODEL=stub-llm
+
+# Playground fixed-session options (optional)
+PLAYGROUND_FIXED_SESSION_ID=
+PLAYGROUND_REWRITE_AGUI=false

--- a/penguiflow/templates/new/wayfinder/.env.example
+++ b/penguiflow/templates/new/wayfinder/.env.example
@@ -1,3 +1,7 @@
 MEMORY_BASE_URL=http://localhost:8000
 WAYFINDER_BASE_URL=http://localhost:9100
 LLM_MODEL=stub-llm
+
+# Playground fixed-session options (optional)
+PLAYGROUND_FIXED_SESSION_ID=
+PLAYGROUND_REWRITE_AGUI=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,92 +4,86 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "penguiflow"
-version = "2.12.4"
+version = "2.12.5"
 description = "Async-first orchestration library for multi-agent and data pipelines"
 readme = "README.md"
 requires-python = ">=3.11"
-license = {file = "LICENSE"}
-authors = [
-    {name = "PenguiFlow Team"},
-]
+license = { file = "LICENSE" }
+authors = [{ name = "PenguiFlow Team" }]
 dependencies = [
-    "pydantic>=2.6",
-    "click>=8.1",
-    "pyyaml>=6.0",
-    "fastapi>=0.118",
-    "uvicorn>=0.32",
-    "databricks-mcp>=0.6.0",
+  "pydantic>=2.6",
+  "click>=8.1",
+  "pyyaml>=6.0",
+  "fastapi>=0.118",
+  "uvicorn>=0.32",
+  "databricks-mcp>=0.6.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "mypy>=1.8",
-    "pytest>=7.4",
-    "pytest-asyncio>=0.23",
-    "pytest-cov>=4.0",
-    "coverage[toml]>=7.0",
-    "hypothesis>=6.103",
-    "ruff>=0.2",
-    "ag-ui-protocol>=0.0.42",
-    "jsonschema>=4.23",
-    "fastapi>=0.118",
-    "httpx>=0.27",
-    "jinja2>=3.1",
-    "pyyaml>=6.0",
-    "uvicorn>=0.32",
-    "tenacity>=9.0.0",
-    "aiohttp>=3.9.0",
-    "grpcio>=1.70.0",
-    "grpcio-status>=1.70.0",
-    "grpcio-tools>=1.70.0",
-    "googleapis-common-protos>=1.66.0",
-    "protobuf>=5.26.0",
-    # LLM provider SDKs for testing native LLM layer
-    "openai>=2.0.0",
-    "anthropic>=0.75.0",
-    "google-genai>=1.57.0",
-    "boto3>=1.42.0",
+  "mypy>=1.8",
+  "pytest>=7.4",
+  "pytest-asyncio>=0.23",
+  "pytest-cov>=4.0",
+  "coverage[toml]>=7.0",
+  "hypothesis>=6.103",
+  "ruff>=0.2",
+  "ag-ui-protocol>=0.0.42",
+  "jsonschema>=4.23",
+  "fastapi>=0.118",
+  "httpx>=0.27",
+  "jinja2>=3.1",
+  "pyyaml>=6.0",
+  "uvicorn>=0.32",
+  "tenacity>=9.0.0",
+  "aiohttp>=3.9.0",
+  "grpcio>=1.70.0",
+  "grpcio-status>=1.70.0",
+  "grpcio-tools>=1.70.0",
+  "googleapis-common-protos>=1.66.0",
+  "protobuf>=5.26.0",
+  # LLM provider SDKs for testing native LLM layer
+  "openai>=2.0.0",
+  "anthropic>=0.75.0",
+  "google-genai>=1.57.0",
+  "boto3>=1.42.0",
 ]
 docs = [
-    "mkdocs>=1.6",
-    "mkdocs-material>=9.6,<9.7",
-    "mkdocstrings[python]>=0.25",
+  "mkdocs>=1.6",
+  "mkdocs-material>=9.6,<9.7",
+  "mkdocstrings[python]>=0.25",
 ]
 cli = [
-    "ag-ui-protocol>=0.0.42",
-    "jinja2>=3.1",
-    "fastapi>=0.118",
-    "uvicorn>=0.32",
+  "ag-ui-protocol>=0.0.42",
+  "jinja2>=3.1",
+  "fastapi>=0.118",
+  "uvicorn>=0.32",
 ]
-a2a-server = [
-    "fastapi>=0.118",
-]
+a2a-server = ["fastapi>=0.118"]
 a2a-grpc = [
-    "grpcio>=1.70.0",
-    "grpcio-status>=1.70.0",
-    "grpcio-tools>=1.70.0",
-    "googleapis-common-protos>=1.66.0",
-    "protobuf>=5.26.0",
+  "grpcio>=1.70.0",
+  "grpcio-status>=1.70.0",
+  "grpcio-tools>=1.70.0",
+  "googleapis-common-protos>=1.66.0",
+  "protobuf>=5.26.0",
 ]
-a2a-client = [
-    "httpx>=0.27",
-]
+a2a-client = ["httpx>=0.27"]
 planner = [
-    "litellm>=1.77.3",
-    "dspy>=3.0.3",
-    "fastmcp>=2.13.0",
-    "utcp>=1.1.0",
-    "utcp-http>=1.0.0",
-    "tenacity>=9.0.0",
-    "aiohttp>=3.9.0",
-    "jsonschema>=4.23",
+  "litellm>=1.77.3",
+  "dspy>=3.0.3",
+  "fastmcp>=2.13.0",
+  "utcp>=1.1.0",
+  "utcp-http>=1.0.0",
+  "tenacity>=9.0.0",
+  "aiohttp>=3.9.0",
+  "jsonschema>=4.23",
 ]
 llm = [
-    "openai>=2.0.0",
-    "anthropic>=0.75.0",
-    "google-genai>=1.57.0",
-    "boto3>=1.42.0",
-    "databricks-sdk>=0.77.0",
+  "openai>=2.0.0",
+  "anthropic>=0.75.0",
+  "google-genai>=1.57.0",
+  "boto3>=1.42.0",
+  "databricks-sdk>=0.77.0",
 ]
 tools-cli = ["utcp-cli>=1.0.0"]
 tools-websocket = ["utcp-websocket>=1.0.0"]
@@ -102,20 +96,30 @@ penguiflow = "penguiflow.cli.main:app"
 Homepage = "https://github.com/hurtener/penguiflow"
 
 [tool.setuptools]
-packages = { find = { include = ["penguiflow*", "penguiflow_a2a*", "examples*"] } }
+packages = { find = { include = [
+  "penguiflow*",
+  "penguiflow_a2a*",
+  "examples*",
+] } }
 include-package-data = true
-exclude-package-data = { "penguiflow" = ["cli/playground_ui/src/*", "cli/playground_ui/src/**/*", "cli/playground_ui/package.json", "cli/playground_ui/tsconfig.json", "cli/playground_ui/vite.config.ts"] }
+exclude-package-data = { "penguiflow" = [
+  "cli/playground_ui/src/*",
+  "cli/playground_ui/src/**/*",
+  "cli/playground_ui/package.json",
+  "cli/playground_ui/tsconfig.json",
+  "cli/playground_ui/vite.config.ts",
+] }
 
 [tool.setuptools.package-data]
 "penguiflow" = [
-    "templates/vscode/*",
-    "templates/new/**/*",
-    "templates/*.yaml",
-    "cli/templates/*",
-    "cli/templates/**/*",
-    "rich_output/registry.json",
-    "cli/playground_ui/dist/*",
-    "cli/playground_ui/dist/**/*",
+  "templates/vscode/*",
+  "templates/new/**/*",
+  "templates/*.yaml",
+  "cli/templates/*",
+  "cli/templates/**/*",
+  "rich_output/registry.json",
+  "cli/playground_ui/dist/*",
+  "cli/playground_ui/dist/**/*",
 ]
 
 [tool.uv]
@@ -125,36 +129,36 @@ default-groups = ["dev"]
 
 [dependency-groups]
 dev = [
-    "mypy>=1.8",
-    "pytest>=7.4",
-    "pytest-asyncio>=0.23",
-    "pytest-cov>=4.0",
-    "coverage[toml]>=7.0",
-    "hypothesis>=6.103",
-    "ruff>=0.2",
-    "ag-ui-protocol>=0.0.42",
-    "jsonschema>=4.23",
-    "fastapi>=0.118",
-    "httpx>=0.27",
-    "jinja2>=3.1",
-    "pyyaml>=6.0",
-    "tenacity>=9.0.0",
-    "aiohttp>=3.9.0",
-    "grpcio>=1.70.0",
-    "grpcio-status>=1.70.0",
-    "grpcio-tools>=1.70.0",
-    "googleapis-common-protos>=1.66.0",
-    "protobuf>=5.26.0",
+  "mypy>=1.8",
+  "pytest>=7.4",
+  "pytest-asyncio>=0.23",
+  "pytest-cov>=4.0",
+  "coverage[toml]>=7.0",
+  "hypothesis>=6.103",
+  "ruff>=0.2",
+  "ag-ui-protocol>=0.0.42",
+  "jsonschema>=4.23",
+  "fastapi>=0.118",
+  "httpx>=0.27",
+  "jinja2>=3.1",
+  "pyyaml>=6.0",
+  "tenacity>=9.0.0",
+  "aiohttp>=3.9.0",
+  "grpcio>=1.70.0",
+  "grpcio-status>=1.70.0",
+  "grpcio-tools>=1.70.0",
+  "googleapis-common-protos>=1.66.0",
+  "protobuf>=5.26.0",
 ]
 
 [tool.ruff]
 line-length = 120
 target-version = "py311"
 extend-exclude = [
-    "ooflow.py",
-    "penguiflow_a2a/grpc/a2a_pb2.py",
-    "penguiflow_a2a/grpc/a2a_pb2_grpc.py",
-    "tmp/codex-skills",
+  "ooflow.py",
+  "penguiflow_a2a/grpc/a2a_pb2.py",
+  "penguiflow_a2a/grpc/a2a_pb2_grpc.py",
+  "tmp/codex-skills",
 ]
 
 [tool.ruff.lint]
@@ -182,22 +186,22 @@ norecursedirs = ["test_generation"]
 [tool.coverage.run]
 source = ["penguiflow"]
 omit = [
-    "*/tests/*",
-    "*/__pycache__/*",
-    "*/.venv/*",
-    "*/planner/dspy_client.py",
-    "*/cli/*",
+  "*/tests/*",
+  "*/__pycache__/*",
+  "*/.venv/*",
+  "*/planner/dspy_client.py",
+  "*/cli/*",
 ]
 
 [tool.coverage.report]
 fail_under = 84.5
 exclude_lines = [
-    "pragma: no cover",
-    "if TYPE_CHECKING:",
-    "raise NotImplementedError",
-    "if __name__ == .__main__.:",
-    "def __repr__",
-    "def __str__",
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+  "def __repr__",
+  "def __str__",
 ]
 precision = 1
 show_missing = true

--- a/tests/cli/test_dev_command.py
+++ b/tests/cli/test_dev_command.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 from click.testing import CliRunner
+from fastapi import FastAPI
 
 from penguiflow.cli import app
 from penguiflow.cli.dev import run_dev
@@ -75,3 +76,29 @@ def test_dev_cli_invokes_run_dev(monkeypatch, tmp_path: Path) -> None:
     assert called["host"] == "0.0.0.0"
     assert called["port"] == 8100
     assert called["open_browser"] is False
+
+
+def test_run_dev_passes_discovered_state_store(monkeypatch, tmp_path: Path) -> None:
+    called = {}
+
+    class FakeServer:
+        def __init__(self, config) -> None:
+            called["config"] = config
+
+        def run(self) -> None:
+            called["run_called"] = True
+
+    def fake_create_playground_app(*, project_root, state_store=None):
+        called["project_root"] = project_root
+        called["state_store"] = state_store
+        return FastAPI()
+
+    monkeypatch.setattr("uvicorn.Server", FakeServer)
+    monkeypatch.setattr("penguiflow.cli.dev._ensure_ui_assets", lambda _: None)
+    monkeypatch.setattr("penguiflow.cli.dev._load_project_state_store", lambda _: {"kind": "store"})
+    monkeypatch.setattr("penguiflow.cli.dev.create_playground_app", fake_create_playground_app)
+
+    run_dev(project_root=tmp_path, host="127.0.0.1", port=9100, open_browser=False)
+
+    assert called["project_root"] == tmp_path
+    assert called["state_store"] == {"kind": "store"}

--- a/tests/cli/test_dev_utils.py
+++ b/tests/cli/test_dev_utils.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 
 import pytest
 
-from penguiflow.cli.dev import CLIError, _ensure_ui_assets, _load_env_file
+from penguiflow.cli.dev import (
+    _MEMORY_BASE_URL_ALIASES,
+    CLIError,
+    _ensure_ui_assets,
+    _load_env_file,
+    _load_project_state_store,
+    _memory_base_url_compat_env,
+)
 
 
 class TestLoadEnvFile:
@@ -98,3 +107,130 @@ class TestEnsureUiAssets:
         (tmp_path / "playground_ui" / "dist").mkdir(parents=True)
         # Should not raise
         _ensure_ui_assets(tmp_path)
+
+
+class TestMemoryBaseUrlCompatibility:
+    def test_temporarily_maps_memory_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MEMORY_BASE_URL", "http://localhost:6004")
+        for key in _MEMORY_BASE_URL_ALIASES:
+            monkeypatch.delenv(key, raising=False)
+        with _memory_base_url_compat_env():
+            for key in _MEMORY_BASE_URL_ALIASES:
+                assert os.environ[key] == "http://localhost:6004"
+        for key in _MEMORY_BASE_URL_ALIASES:
+            assert key not in os.environ
+
+    def test_preserves_existing_legacy_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        alias_key = _MEMORY_BASE_URL_ALIASES[0]
+        monkeypatch.setenv(alias_key, "http://platform:7000")
+        monkeypatch.setenv("MEMORY_BASE_URL", "http://memory:6004")
+        with _memory_base_url_compat_env():
+            assert os.environ[alias_key] == "http://platform:7000"
+        assert os.environ[alias_key] == "http://platform:7000"
+
+
+class TestProjectStateStoreLoader:
+    def test_loads_state_store_builder_from_project_src(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        agentiv_dir = tmp_path / "src" / "agentiv"
+        agentiv_dir.mkdir(parents=True)
+        (agentiv_dir / "__init__.py").write_text("", encoding="utf-8")
+        (agentiv_dir / "state_store.py").write_text(
+            "def build_agentiv_state_store_from_env():\n"
+            "    return {'kind': 'state_store'}\n",
+            encoding="utf-8",
+        )
+        sys.modules.pop("agentiv", None)
+        sys.modules.pop("agentiv.state_store", None)
+        sys.modules.pop("agentiv.state_store_enhanced", None)
+        store = _load_project_state_store(tmp_path)
+        assert store == {"kind": "state_store"}
+
+    def test_builder_can_use_memory_base_url_only(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        alias_key = _MEMORY_BASE_URL_ALIASES[0]
+        agentiv_dir = tmp_path / "src" / "agentiv"
+        agentiv_dir.mkdir(parents=True)
+        (agentiv_dir / "__init__.py").write_text("", encoding="utf-8")
+        (agentiv_dir / "state_store.py").write_text(
+            "import os\n"
+            "def build_agentiv_state_store_from_env():\n"
+            f"    val = os.getenv({alias_key!r})\n"
+            "    if not val:\n"
+            f"        raise ValueError('missing {alias_key}')\n"
+            "    return {'kind': 'state_store', 'url': val}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv(alias_key, raising=False)
+        monkeypatch.setenv("MEMORY_BASE_URL", "http://memory-only:6004")
+        sys.modules.pop("agentiv", None)
+        sys.modules.pop("agentiv.state_store", None)
+        sys.modules.pop("agentiv.state_store_enhanced", None)
+
+        store = _load_project_state_store(tmp_path)
+        assert store == {"kind": "state_store", "url": "http://memory-only:6004"}
+
+    def test_builder_helper_ignoring_env_still_uses_memory_base_url(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        alias_key = _MEMORY_BASE_URL_ALIASES[0]
+        agentiv_dir = tmp_path / "src" / "agentiv"
+        agentiv_dir.mkdir(parents=True)
+        (agentiv_dir / "__init__.py").write_text("", encoding="utf-8")
+        (agentiv_dir / "state_store.py").write_text(
+            "def from_env_or_dotenv(env_var_name: str, default: str) -> str:\n"
+            "    # Simulate legacy helper that ignores os.environ locally.\n"
+            "    return default\n"
+            "def build_agentiv_state_store_from_env():\n"
+            f"    val = from_env_or_dotenv({alias_key!r}, '')\n"
+            "    if not val:\n"
+            "        raise ValueError('missing alias url')\n"
+            "    return {'kind': 'state_store', 'url': val}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("MEMORY_BASE_URL", "http://memory-helper:6004")
+        monkeypatch.delenv(alias_key, raising=False)
+        sys.modules.pop("agentiv", None)
+        sys.modules.pop("agentiv.state_store", None)
+        sys.modules.pop("agentiv.state_store_enhanced", None)
+
+        store = _load_project_state_store(tmp_path)
+        assert store == {"kind": "state_store", "url": "http://memory-helper:6004"}
+
+    def test_builder_helper_cwd_dotenv_value_does_not_override_memory_base_url(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        alias_key = _MEMORY_BASE_URL_ALIASES[0]
+        agentiv_dir = tmp_path / "src" / "agentiv"
+        agentiv_dir.mkdir(parents=True)
+        (agentiv_dir / "__init__.py").write_text("", encoding="utf-8")
+        (agentiv_dir / "state_store.py").write_text(
+            "def from_env_or_dotenv(env_var_name: str, default: str) -> str:\n"
+            "    if env_var_name == 'PLATFORM_URL':\n"
+            "        return 'http://localhost:8000'\n"
+            "    return default\n"
+            "def build_agentiv_state_store_from_env():\n"
+            "    val = from_env_or_dotenv('PLATFORM_URL', '')\n"
+            "    if not val:\n"
+            "        raise ValueError('missing alias url')\n"
+            "    return {'kind': 'state_store', 'url': val}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("MEMORY_BASE_URL", "http://memory-final:6004")
+        monkeypatch.delenv(alias_key, raising=False)
+        sys.modules.pop("agentiv", None)
+        sys.modules.pop("agentiv.state_store", None)
+        sys.modules.pop("agentiv.state_store_enhanced", None)
+
+        store = _load_project_state_store(tmp_path)
+        assert store == {"kind": "state_store", "url": "http://memory-final:6004"}

--- a/tests/cli/test_playground_endpoints.py
+++ b/tests/cli/test_playground_endpoints.py
@@ -68,6 +68,66 @@ class MockAgentWrapper(AgentWrapper):
         return self._chat_result
 
 
+class CapturingAgentWrapper(MockAgentWrapper):
+    """Wrapper that records the final chat inputs seen by the backend."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.last_chat_session_id: str | None = None
+        self.last_chat_tool_context: dict[str, Any] | None = None
+
+    async def chat(
+        self,
+        query: str,
+        *,
+        session_id: str,
+        llm_context: dict[str, Any] | None = None,
+        tool_context: dict[str, Any] | None = None,
+        event_consumer: Any = None,
+        trace_id_hint: str | None = None,
+        steering: Any = None,
+    ) -> ChatResult:
+        del query, llm_context, event_consumer, trace_id_hint, steering
+        self.last_chat_session_id = session_id
+        self.last_chat_tool_context = dict(tool_context or {})
+        return ChatResult(
+            trace_id="captured-trace",
+            session_id=session_id,
+            answer="captured",
+            metadata={"ok": True},
+            pause=None,
+        )
+
+
+class _ArtifactRef:
+    def __init__(self, artifact_id: str = "artifact-1") -> None:
+        self.id = artifact_id
+        self.mime_type = "text/plain"
+        self.filename = "artifact.txt"
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "mime_type": self.mime_type,
+            "filename": self.filename,
+        }
+
+
+class RecordingArtifactStore:
+    def __init__(self) -> None:
+        self.last_session_check: str | None = None
+
+    async def get_with_session_check(self, artifact_id: str, session_id: str) -> bytes | None:
+        self.last_session_check = session_id
+        return f"artifact:{artifact_id}:{session_id}".encode()
+
+    async def get(self, artifact_id: str) -> bytes | None:
+        return f"artifact:{artifact_id}:raw".encode()
+
+    async def get_ref(self, artifact_id: str) -> _ArtifactRef | None:
+        return _ArtifactRef(artifact_id=artifact_id)
+
+
 class TestHealthEndpoint:
     """Tests for /health endpoint (line 719)."""
 
@@ -158,6 +218,38 @@ class TestUIMetaEndpoint:
         assert "planner" in data
         assert "services" in data
         assert "tools" in data
+
+
+class TestUISetupEndpoint:
+    """Tests for /ui/setup runtime fixed-session configuration."""
+
+    def test_ui_setup_reads_env_defaults(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("PLAYGROUND_FIXED_SESSION_ID", "env-session")
+        monkeypatch.setenv("PLAYGROUND_REWRITE_AGUI", "true")
+        wrapper = MockAgentWrapper()
+        app = create_playground_app(project_root=tmp_path, agent=wrapper)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/ui/setup")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["fixed_session_id"] == "env-session"
+        assert payload["rewrite_agui"] is True
+        assert payload["fixed_session_source"] == "env"
+
+    def test_ui_setup_runtime_override_wins(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("PLAYGROUND_FIXED_SESSION_ID", "env-session")
+        wrapper = MockAgentWrapper()
+        app = create_playground_app(project_root=tmp_path, agent=wrapper)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        update = client.put("/ui/setup", json={"fixed_session_id": "runtime-session", "rewrite_agui": True})
+        assert update.status_code == 200
+        payload = update.json()
+        assert payload["fixed_session_id"] == "runtime-session"
+        assert payload["fixed_session_source"] == "runtime"
+        assert payload["rewrite_agui"] is True
+        assert payload["rewrite_agui_source"] == "runtime"
 
 
 class TestUIComponentsEndpoint:
@@ -392,6 +484,60 @@ class TestChatEndpoint:
         assert "Chat failed" in response.json()["detail"]
 
 
+class TestFixedSessionMiddleware:
+    """Integration tests for fixed-session rewrite behavior."""
+
+    def test_rewrites_chat_body_session_fields(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("PLAYGROUND_FIXED_SESSION_ID", "fixed-session-123")
+        wrapper = CapturingAgentWrapper()
+        app = create_playground_app(project_root=tmp_path, agent=wrapper)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.post(
+            "/chat",
+            json={
+                "query": "Hello",
+                "session_id": "request-session",
+                "tool_context": {"session_id": "tool-session"},
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["session_id"] == "fixed-session-123"
+        assert wrapper.last_chat_session_id == "fixed-session-123"
+        assert wrapper.last_chat_tool_context is not None
+        assert wrapper.last_chat_tool_context["session_id"] == "fixed-session-123"
+
+    def test_request_override_header_beats_env_when_runtime_not_set(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("PLAYGROUND_FIXED_SESSION_ID", "env-session")
+        wrapper = CapturingAgentWrapper()
+        app = create_playground_app(project_root=tmp_path, agent=wrapper)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.post(
+            "/chat",
+            headers={"X-Playground-Fixed-Session-ID": "request-session"},
+            json={"query": "Hello", "session_id": "body-session"},
+        )
+        assert response.status_code == 200
+        assert response.json()["session_id"] == "request-session"
+        assert wrapper.last_chat_session_id == "request-session"
+
+    def test_invalid_json_passes_through_without_middleware_crash(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("PLAYGROUND_FIXED_SESSION_ID", "fixed-session-123")
+        wrapper = CapturingAgentWrapper()
+        app = create_playground_app(project_root=tmp_path, agent=wrapper)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.post(
+            "/chat",
+            content="{invalid-json",
+            headers={"Content-Type": "application/json"},
+        )
+        # FastAPI validation failure is expected; middleware should not convert this into 500.
+        assert response.status_code == 422
+
+
 class TestChatStreamEndpoint:
     """Tests for /chat/stream endpoint (lines 831-881)."""
 
@@ -563,6 +709,34 @@ class TestArtifactEndpoints:
         response = client.get("/artifacts/test-id/meta")
         assert response.status_code == 501
         assert "Artifact storage not enabled" in response.json()["detail"]
+
+    def test_get_artifact_rewrites_query_session_id(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("PLAYGROUND_FIXED_SESSION_ID", "fixed-session-query")
+        wrapper = MockAgentWrapper()
+        recording_store = RecordingArtifactStore()
+        wrapper._planner = MagicMock()
+        wrapper._planner.artifact_store = recording_store
+
+        app = create_playground_app(project_root=tmp_path, agent=wrapper)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/artifacts/a-1", params={"session_id": "wrong-query"})
+        assert response.status_code == 200
+        assert recording_store.last_session_check == "fixed-session-query"
+
+    def test_get_artifact_rewrites_session_header(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("PLAYGROUND_FIXED_SESSION_ID", "fixed-session-header")
+        wrapper = MockAgentWrapper()
+        recording_store = RecordingArtifactStore()
+        wrapper._planner = MagicMock()
+        wrapper._planner.artifact_store = recording_store
+
+        app = create_playground_app(project_root=tmp_path, agent=wrapper)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/artifacts/a-2", headers={"X-Session-ID": "wrong-header"})
+        assert response.status_code == 200
+        assert recording_store.last_session_check == "fixed-session-header"
 
 
 class TestResourceEndpoints:

--- a/tests/cli/test_playground_helpers.py
+++ b/tests/cli/test_playground_helpers.py
@@ -8,6 +8,9 @@ from pathlib import Path
 import pytest
 
 from penguiflow.cli.playground import (
+    FixedSessionRewriteMiddleware,
+    PlaygroundSetupState,
+    SetupUpdateRequest,
     _discover_spec_path,
     _done_frame,
     _error_frame,
@@ -74,6 +77,79 @@ class TestMergeContexts:
         secondary = {"b": 3, "c": 4}
         result = _merge_contexts(primary, secondary)
         assert result == {"a": 1, "b": 3, "c": 4}
+
+
+class TestFixedSessionRewriteMiddlewareHelpers:
+    """Tests for fixed-session payload rewrite helpers."""
+
+    def test_rewrites_agui_thread_ids_when_enabled(self) -> None:
+        payload = {"thread_id": "old-thread", "threadId": "old-thread-camel", "run_id": "run-1"}
+        rewritten = FixedSessionRewriteMiddleware._rewrite_json_payload(
+            "/agui/resume",
+            payload,
+            "fixed-thread",
+            rewrite_agui=True,
+        )
+        assert rewritten["thread_id"] == "fixed-thread"
+        assert rewritten["threadId"] == "fixed-thread"
+        assert rewritten["run_id"] == "run-1"
+
+    def test_does_not_rewrite_agui_thread_ids_when_disabled(self) -> None:
+        payload = {"threadId": "original-thread", "runId": "run-2"}
+        rewritten = FixedSessionRewriteMiddleware._rewrite_json_payload(
+            "/agui/agent",
+            payload,
+            "fixed-thread",
+            rewrite_agui=False,
+        )
+        assert rewritten["threadId"] == "original-thread"
+        assert rewritten["runId"] == "run-2"
+
+    def test_rewrites_query_and_header_session_id(self) -> None:
+        scope = {
+            "query_string": b"trace_id=t1&session_id=old-session",
+            "headers": [(b"x-session-id", b"old-header")],
+        }
+        rewritten_scope, query_from = FixedSessionRewriteMiddleware._rewrite_query_session(scope, "fixed-session")
+        rewritten_scope, header_from = FixedSessionRewriteMiddleware._rewrite_session_header(
+            rewritten_scope,
+            "fixed-session",
+        )
+        assert query_from == "old-session"
+        assert header_from == "old-header"
+        assert rewritten_scope["query_string"] == b"trace_id=t1&session_id=fixed-session"
+        assert rewritten_scope["headers"][0] == (b"x-session-id", b"fixed-session")
+
+    def test_invalid_json_payload_returns_none(self) -> None:
+        parsed = FixedSessionRewriteMiddleware._parse_json_body(b"{not-json")
+        assert parsed is None
+
+
+class TestPlaygroundSetupState:
+    def test_precedence_runtime_then_request_then_env(self) -> None:
+        state = PlaygroundSetupState(env_fixed_session_id="env-session", env_rewrite_agui=False)
+
+        # Request override beats env when runtime override is not set.
+        request_value = state.effective_fixed_session_id([(b"x-playground-fixed-session-id", b"request-session")])
+        assert request_value == "request-session"
+
+        updated = state.update_runtime(SetupUpdateRequest(fixed_session_id="runtime-session"))
+        assert updated.fixed_session_id == "runtime-session"
+
+        # Runtime override beats request override.
+        effective = state.effective_fixed_session_id([(b"x-playground-fixed-session-id", b"request-session")])
+        assert effective == "runtime-session"
+
+    def test_snapshot_tracks_sources(self) -> None:
+        state = PlaygroundSetupState(env_fixed_session_id="env-session", env_rewrite_agui=True)
+        snapshot = state.snapshot()
+        assert snapshot.fixed_session_source == "env"
+        assert snapshot.rewrite_agui_source == "env"
+
+        updated = state.update_runtime(SetupUpdateRequest(fixed_session_id="runtime-session", rewrite_agui=False))
+        assert updated.fixed_session_source == "runtime"
+        assert updated.rewrite_agui_source == "runtime"
+        assert updated.rewrite_agui is False
 
 
 class TestDiscoverSpecPath:

--- a/tests/test_cli_new.py
+++ b/tests/test_cli_new.py
@@ -67,6 +67,23 @@ def test_cli_new_command_creates_project(tmp_path: Path) -> None:
     "template",
     ["minimal", "react", "parallel", "flow", "controller", "rag_server", "wayfinder", "analyst", "enterprise"],
 )
+def test_generated_env_example_includes_fixed_session_options(tmp_path: Path, template: str) -> None:
+    name = f"{template}-env-agent"
+    project_dir, _ = _project_paths(tmp_path, name)
+    result = run_new(name=name, template=template, output_dir=tmp_path, quiet=True)
+    assert result.success
+
+    env_example = project_dir / ".env.example"
+    assert env_example.exists()
+    content = env_example.read_text(encoding="utf-8")
+    assert "PLAYGROUND_FIXED_SESSION_ID=" in content
+    assert "PLAYGROUND_REWRITE_AGUI=" in content
+
+
+@pytest.mark.parametrize(
+    "template",
+    ["minimal", "react", "parallel", "flow", "controller", "rag_server", "wayfinder", "analyst", "enterprise"],
+)
 def test_generated_project_tests_pass(tmp_path: Path, template: str) -> None:
     name = f"{template}-proj"
     project_dir, _ = _project_paths(tmp_path, name)


### PR DESCRIPTION
 ## Summary

  This PR adds a non-breaking Playground enhancement to support fixed session IDs without requiring a custom wrapper script.

  It introduces:

  - Runtime setup controls in the Playground Setup tab to set/clear a fixed session ID.
  - Env-based configuration fallback:
      - PLAYGROUND_FIXED_SESSION_ID
      - PLAYGROUND_REWRITE_AGUI (default false)
  - Request rewrite middleware so Playground calls can consistently use the effective fixed session ID.
  - penguiflow dev project state-store auto-wiring improvements (with compatibility handling for legacy builders using MEMORY_BASE_URL aliasing).
  - Template updates so newly generated projects include the new Playground env vars in .env.example.
  - Docs updates for dev / new commands.

  ## Why

  Previously, stable session testing required a custom playground.py wrapper to hijack IDs.
  Now this is available natively in PenguiFlow Playground, making persistence/state-store testing easier and consistent across projects.

  ## Non-Breaking Change

  This is additive and optional:

  - If PLAYGROUND_FIXED_SESSION_ID is not set and no runtime override is saved, behavior remains unchanged (dynamic sessions).
  - Existing projects continue to work as before.

  ## Key Behavior

  - Effective fixed session source precedence:
      1. Runtime value from Setup tab
      2. Env value (PLAYGROUND_FIXED_SESSION_ID)
      3. No override (dynamic)
  - When fixed session mode is active, Playground rewrites session identifiers in relevant request query/header/body paths.
  - Optional AG-UI thread rewrite is controlled by PLAYGROUND_REWRITE_AGUI.

  ## Validation

  - ruff checks pass on touched Python files.
  - Updated test suites pass for the changed CLI/helpers/new-template areas.
  - Template coverage added to assert new env vars are present in generated .env.example.
  - Changelog and version aligned to 2.12.5