### PR TITLE
Add tag/namespace filters to tool_search and skill_search

### DIFF
--- a/penguiflow/__init__.py
+++ b/penguiflow/__init__.py
@@ -227,4 +227,4 @@ __all__ = [
     "TrajectoryStep",
 ]
 
-__version__ = "3.8.1"
+__version__ = "3.9.0"

--- a/penguiflow/planner/tool_search_cache.py
+++ b/penguiflow/planner/tool_search_cache.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from ..catalog import NodeSpec, ToolLoadingMode
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 _SIDE_EFFECT_RANK = {
     "pure": 0,
     "read": 1,
@@ -27,6 +27,7 @@ class _ToolRecord:
     name: str
     description: str
     tags: list[str]
+    declared_tags: list[str]
     side_effects: str
     loading_mode: str
     record_hash: str
@@ -80,10 +81,13 @@ class ToolSearchCache:
         with sqlite3.connect(self._db_path) as conn:
             conn.execute("PRAGMA journal_mode=WAL")
             existing_fingerprint = _get_meta(conn, "catalog_fingerprint")
+            existing_schema_version = _get_meta(conn, "schema_version")
+            schema_outdated = existing_schema_version != str(_SCHEMA_VERSION)
             if (
                 existing_fingerprint == fingerprint
                 and not self._rebuild_cache_on_init
                 and self._enable_incremental_index
+                and not schema_outdated
             ):
                 return
 
@@ -95,7 +99,14 @@ class ToolSearchCache:
                 existing = {row[0]: row[1] for row in conn.execute("SELECT name, record_hash FROM tools")}
                 desired = {record.name: record.record_hash for record in records}
                 to_delete = set(existing) - set(desired)
-                to_upsert = [record for record in records if existing.get(record.name) != record.record_hash]
+                if schema_outdated:
+                    # Force re-upsert so new columns (e.g. declared_tags) get
+                    # populated for every row without disturbing the FTS index.
+                    to_upsert = records
+                else:
+                    to_upsert = [
+                        record for record in records if existing.get(record.name) != record.record_hash
+                    ]
 
             if to_delete:
                 for name in to_delete:
@@ -108,14 +119,16 @@ class ToolSearchCache:
                         name,
                         description,
                         tags,
+                        declared_tags,
                         side_effects,
                         loading_mode,
                         record_hash
                     )
-                    VALUES (?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(name) DO UPDATE SET
                         description=excluded.description,
                         tags=excluded.tags,
+                        declared_tags=excluded.declared_tags,
                         side_effects=excluded.side_effects,
                         loading_mode=excluded.loading_mode,
                         record_hash=excluded.record_hash
@@ -125,6 +138,7 @@ class ToolSearchCache:
                             record.name,
                             record.description,
                             json.dumps(record.tags, ensure_ascii=False),
+                            json.dumps(record.declared_tags, ensure_ascii=False),
                             record.side_effects,
                             record.loading_mode,
                             record.record_hash,
@@ -144,6 +158,8 @@ class ToolSearchCache:
         limit: int,
         include_always_loaded: bool,
         allowed_names: set[str] | None = None,
+        tags: Sequence[str] = (),
+        namespace: str | None = None,
     ) -> tuple[list[dict[str, Any]], str]:
         cleaned_query = query.strip()
         if not cleaned_query:
@@ -154,6 +170,11 @@ class ToolSearchCache:
             effective_search_type = "regex" if self._fts_fallback_to_regex else "exact"
 
         limit = min(max(int(limit), 1), self._max_search_results)
+
+        required_tags = _normalise_tag_filter(tags)
+        namespace_filter = namespace.strip() if isinstance(namespace, str) else None
+        if namespace_filter == "":
+            namespace_filter = None
 
         self._ensure_schema()
         with sqlite3.connect(self._db_path) as conn:
@@ -182,6 +203,11 @@ class ToolSearchCache:
             if include_always_loaded
             or not _is_always_loaded(item["name"], item["loading_mode"], self._always_loaded_patterns)
         ]
+
+        if required_tags:
+            filtered = [item for item in filtered if _matches_tag_filter(item.get("declared_tags", []), required_tags)]
+        if namespace_filter is not None:
+            filtered = [item for item in filtered if _matches_namespace(item["name"], namespace_filter)]
 
         sorted_results = sorted(
             filtered,
@@ -217,12 +243,19 @@ class ToolSearchCache:
                     name TEXT PRIMARY KEY,
                     description TEXT NOT NULL,
                     tags TEXT NOT NULL,
+                    declared_tags TEXT NOT NULL DEFAULT '[]',
                     side_effects TEXT NOT NULL,
                     loading_mode TEXT NOT NULL,
                     record_hash TEXT NOT NULL
                 )
                 """
             )
+            # Schema v2 migration: add declared_tags column on pre-existing databases.
+            try:
+                conn.execute("ALTER TABLE tools ADD COLUMN declared_tags TEXT NOT NULL DEFAULT '[]'")
+            except sqlite3.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS tool_index_meta (
@@ -293,8 +326,8 @@ class ToolSearchCache:
             allowed_params.extend(sorted(allowed_names))
 
         sql = (
-            "SELECT tools.name, tools.description, tools.tags, tools.side_effects, tools.loading_mode, "
-            "bm25(tools_fts) as rank "
+            "SELECT tools.name, tools.description, tools.tags, tools.declared_tags, "
+            "tools.side_effects, tools.loading_mode, bm25(tools_fts) as rank "
             "FROM tools_fts JOIN tools ON tools_fts.rowid = tools.rowid "
             "WHERE tools_fts MATCH ?" + clause
         )
@@ -321,7 +354,7 @@ class ToolSearchCache:
 
         scored: list[dict[str, Any]] = []
         raw_scores: list[float] = []
-        for name, description, tags, side_effects, loading_mode, raw in rows:
+        for name, description, tags, declared_tags, side_effects, loading_mode, raw in rows:
             raw_value = float(raw) if raw is not None else 0.0
             raw_value = max(raw_value, 0.0)
             score_raw = 1.0 / (1.0 + raw_value)
@@ -331,6 +364,7 @@ class ToolSearchCache:
                     "name": name,
                     "description": description or "",
                     "tags": _parse_tags(tags),
+                    "declared_tags": _parse_tags(declared_tags),
                     "side_effects": side_effects or "pure",
                     "loading_mode": loading_mode or ToolLoadingMode.ALWAYS.value,
                     "match_type": "fts",
@@ -392,7 +426,8 @@ def _tool_record(spec: NodeSpec) -> _ToolRecord:
     loading_mode = spec.loading_mode
     if isinstance(loading_mode, str):
         loading_mode = ToolLoadingMode(loading_mode)
-    tags = list(spec.tags)
+    declared_tags = [str(tag) for tag in spec.tags if str(tag).strip()]
+    tags = list(declared_tags)
     for token in _fts_tokens(spec.name):
         lowered = token.lower()
         if lowered not in tags:
@@ -404,6 +439,7 @@ def _tool_record(spec: NodeSpec) -> _ToolRecord:
         "name": spec.name,
         "description": spec.desc,
         "tags": tags,
+        "declared_tags": declared_tags,
         "side_effects": spec.side_effects,
         "loading_mode": loading_mode.value,
         "examples": spec.examples_payload(),
@@ -413,6 +449,7 @@ def _tool_record(spec: NodeSpec) -> _ToolRecord:
         name=spec.name,
         description=spec.desc,
         tags=tags,
+        declared_tags=declared_tags,
         side_effects=spec.side_effects,
         loading_mode=loading_mode.value,
         record_hash=record_hash,
@@ -450,7 +487,7 @@ def _set_meta(conn: sqlite3.Connection, key: str, value: str) -> None:
 def _fetch_tool_rows(
     conn: sqlite3.Connection,
     allowed_names: set[str] | None,
-) -> list[tuple[str, str, str, str, str]]:
+) -> list[tuple[str, str, str, str, str, str]]:
     if allowed_names is not None and not allowed_names:
         return []
     clause = ""
@@ -459,28 +496,33 @@ def _fetch_tool_rows(
         placeholders = ", ".join("?" for _ in allowed_names)
         clause = f" WHERE name IN ({placeholders})"
         params.extend(sorted(allowed_names))
-    sql = f"SELECT name, description, tags, side_effects, loading_mode FROM tools{clause}"
+    sql = (
+        "SELECT name, description, tags, declared_tags, side_effects, loading_mode "
+        f"FROM tools{clause}"
+    )
     return [
         (
             str(name),
             str(description or ""),
             str(tags or "[]"),
+            str(declared_tags or "[]"),
             str(side_effects or "pure"),
             str(loading_mode or ToolLoadingMode.ALWAYS.value),
         )
-        for name, description, tags, side_effects, loading_mode in conn.execute(sql, params)
+        for name, description, tags, declared_tags, side_effects, loading_mode in conn.execute(sql, params)
     ]
 
 
 def _score_exact(
     query: str,
-    rows: list[tuple[str, str, str, str, str]],
+    rows: list[tuple[str, str, str, str, str, str]],
     preferred_namespaces: Sequence[str],
 ) -> list[dict[str, Any]]:
     query_lower = query.lower()
     results: list[dict[str, Any]] = []
-    for name, description, tags_raw, side_effects, loading_mode in rows:
+    for name, description, tags_raw, declared_tags_raw, side_effects, loading_mode in rows:
         tags = _parse_tags(tags_raw)
+        declared_tags = _parse_tags(declared_tags_raw)
         if not _exact_match(query_lower, name, description, tags):
             continue
         results.append(
@@ -488,6 +530,7 @@ def _score_exact(
                 "name": name,
                 "description": description,
                 "tags": tags,
+                "declared_tags": declared_tags,
                 "side_effects": side_effects,
                 "loading_mode": loading_mode,
                 "match_type": "exact",
@@ -501,7 +544,7 @@ def _score_exact(
 
 def _score_regex(
     query: str,
-    rows: list[tuple[str, str, str, str, str]],
+    rows: list[tuple[str, str, str, str, str, str]],
     preferred_namespaces: Sequence[str],
 ) -> list[dict[str, Any]]:
     regex: re.Pattern[str] | None = None
@@ -522,8 +565,9 @@ def _score_regex(
             return []
 
     results: list[dict[str, Any]] = []
-    for name, description, tags_raw, side_effects, loading_mode in rows:
+    for name, description, tags_raw, declared_tags_raw, side_effects, loading_mode in rows:
         tags = _parse_tags(tags_raw)
+        declared_tags = _parse_tags(declared_tags_raw)
         score = _regex_score(regex, name, description, tags)
         if score is None:
             continue
@@ -532,6 +576,7 @@ def _score_regex(
                 "name": name,
                 "description": description,
                 "tags": tags,
+                "declared_tags": declared_tags,
                 "side_effects": side_effects,
                 "loading_mode": loading_mode,
                 "match_type": "regex",
@@ -587,6 +632,31 @@ def _namespace_rank(name: str, preferred: Sequence[str]) -> int:
         return preferred.index(namespace)
     except ValueError:
         return len(preferred) + 1
+
+
+def _normalise_tag_filter(tags: Sequence[str]) -> list[str]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for tag in tags or ():
+        text = str(tag).strip()
+        if not text or text in seen:
+            continue
+        cleaned.append(text)
+        seen.add(text)
+    return cleaned
+
+
+def _matches_tag_filter(declared_tags: Sequence[str], required: Sequence[str]) -> bool:
+    if not required:
+        return True
+    declared = {str(tag) for tag in declared_tags or ()}
+    return all(tag in declared for tag in required)
+
+
+def _matches_namespace(name: str, namespace: str) -> bool:
+    if not namespace:
+        return True
+    return name == namespace or name.startswith(namespace + ".")
 
 
 def _is_always_loaded(name: str, loading_mode: str, patterns: Sequence[str]) -> bool:

--- a/penguiflow/planner/tool_search_tool.py
+++ b/penguiflow/planner/tool_search_tool.py
@@ -13,6 +13,20 @@ class ToolSearchArgs(BaseModel):
     search_type: Literal["fts", "regex", "exact"] = "fts"
     limit: int = Field(default=8, ge=1, le=20)
     include_always_loaded: bool = False
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional declared-tag AND filter. Each tag must appear in the tool's "
+            "declared tag list. Empty list disables the filter (back-compat default)."
+        ),
+    )
+    namespace: str | None = Field(
+        default=None,
+        description=(
+            "Optional dot-prefix namespace filter. Matches tools whose name equals "
+            "the namespace or starts with '<namespace>.'. None disables the filter."
+        ),
+    )
 
 
 class ToolSearchResult(BaseModel):
@@ -48,6 +62,8 @@ async def tool_search(args: ToolSearchArgs, ctx: Any) -> ToolSearchResponse:
         limit=limit,
         include_always_loaded=bool(args.include_always_loaded),
         allowed_names=set(allowed_names),
+        tags=tuple(args.tags),
+        namespace=args.namespace,
     )
 
     tools = [ToolSearchResult(**item) for item in results]
@@ -65,6 +81,8 @@ async def tool_search(args: ToolSearchArgs, ctx: Any) -> ToolSearchResponse:
                     "requested_search_type": args.search_type,
                     "effective_search_type": effective,
                     "results_count": len(tools),
+                    "tags": list(args.tags),
+                    "namespace": args.namespace,
                 },
             )
         )

--- a/penguiflow/skills/local_store.py
+++ b/penguiflow/skills/local_store.py
@@ -258,6 +258,8 @@ class LocalSkillStore:
         task_type: SkillTaskType | None,
         scope_clause: str,
         scope_params: Sequence[Any],
+        tags: Sequence[str] = (),
+        namespace: str | None = None,
     ) -> tuple[list[dict[str, Any]], SkillSearchType]:
         cleaned_query = query.strip()
         if not cleaned_query:
@@ -265,6 +267,11 @@ class LocalSkillStore:
         effective: SkillSearchType = search_type
         if search_type == "fts" and not self.fts_available:
             effective = "regex" if self._fts_fallback_to_regex else "exact"
+
+        required_tags = _normalise_tag_filter(tags)
+        namespace_filter = namespace.strip() if isinstance(namespace, str) else None
+        if namespace_filter == "":
+            namespace_filter = None
 
         self._ensure_schema()
         with sqlite3.connect(self._db_path) as conn:
@@ -284,6 +291,12 @@ class LocalSkillStore:
                         )
             else:
                 results = _search_regex_exact(conn, cleaned_query, effective, task_type, scope_clause, scope_params)
+
+        if required_tags:
+            results = [item for item in results if _matches_tag_filter(item.get("tags", ()), required_tags)]
+        if namespace_filter is not None:
+            results = [item for item in results if _matches_namespace(item["name"], namespace_filter)]
+
         results = sorted(results, key=lambda item: (-float(item["score"]), len(item["name"]), item["name"]))
         start = max(int(offset), 0)
         end = start + max(int(limit), 1)
@@ -310,6 +323,8 @@ class LocalSkillStore:
         origin: SkillOrigin | None,
         scope_clause: str,
         scope_params: Sequence[Any],
+        tags: Sequence[str] = (),
+        namespace: str | None = None,
     ) -> tuple[list[SkillRecord], int]:
         page = max(int(page), 1)
         page_size = max(int(page_size), 1)
@@ -325,16 +340,41 @@ class LocalSkillStore:
             filters.append("origin = ?")
             params.append(origin)
         where = " AND ".join(filters) if filters else "1=1"
-        limit = page_size
-        offset = (page - 1) * page_size
-        sql = f"SELECT {_SKILL_COLUMNS} FROM skills WHERE {where} ORDER BY name LIMIT ? OFFSET ?"
+
+        required_tags = _normalise_tag_filter(tags)
+        namespace_filter = namespace.strip() if isinstance(namespace, str) else None
+        if namespace_filter == "":
+            namespace_filter = None
+        post_filter = bool(required_tags) or namespace_filter is not None
+
         with sqlite3.connect(self._db_path) as conn:
-            rows = conn.execute(sql, params + [limit, offset]).fetchall()
-            total = conn.execute(
-                f"SELECT COUNT(1) FROM skills WHERE {where}",
-                params,
-            ).fetchone()[0]
-        return [_row_to_skill(row) for row in rows], int(total)
+            if not post_filter:
+                # Fast path: SQL handles paging + COUNT directly.
+                limit = page_size
+                offset = (page - 1) * page_size
+                sql = (
+                    f"SELECT {_SKILL_COLUMNS} FROM skills WHERE {where} "
+                    "ORDER BY name LIMIT ? OFFSET ?"
+                )
+                rows = conn.execute(sql, params + [limit, offset]).fetchall()
+                total = conn.execute(
+                    f"SELECT COUNT(1) FROM skills WHERE {where}",
+                    params,
+                ).fetchone()[0]
+                return [_row_to_skill(row) for row in rows], int(total)
+
+            # Filtered path: load all candidates, apply Python filter, then page.
+            sql = f"SELECT {_SKILL_COLUMNS} FROM skills WHERE {where} ORDER BY name"
+            all_rows = conn.execute(sql, params).fetchall()
+        records = [_row_to_skill(row) for row in all_rows]
+        if required_tags:
+            records = [record for record in records if _matches_tag_filter(record.tags, required_tags)]
+        if namespace_filter is not None:
+            records = [record for record in records if _matches_namespace(record.name, namespace_filter)]
+        total = len(records)
+        start = (page - 1) * page_size
+        end = start + page_size
+        return records[start:end], total
 
     def list_recent(
         self,
@@ -763,6 +803,31 @@ def _fts_or_query(tokens: Sequence[str]) -> str:
     return " OR ".join(f'"{token}"' for token in tokens)
 
 
+def _normalise_tag_filter(tags: Sequence[str]) -> list[str]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for tag in tags or ():
+        text = str(tag).strip()
+        if not text or text in seen:
+            continue
+        cleaned.append(text)
+        seen.add(text)
+    return cleaned
+
+
+def _matches_tag_filter(declared_tags: Sequence[str], required: Sequence[str]) -> bool:
+    if not required:
+        return True
+    declared = {str(tag) for tag in declared_tags or ()}
+    return all(tag in declared for tag in required)
+
+
+def _matches_namespace(name: str, namespace: str) -> bool:
+    if not namespace:
+        return True
+    return name == namespace or name.startswith(namespace + ".")
+
+
 def _search_regex_exact(
     conn: sqlite3.Connection,
     query: str,
@@ -820,6 +885,7 @@ def _score_exact(query: str, rows: list[tuple[str, str | None, str | None, str, 
                 "title": title,
                 "trigger": trigger,
                 "task_type": task_type_value,
+                "tags": tags,
                 "match_type": "exact",
                 "score": 1.0,
             }
@@ -856,6 +922,7 @@ def _score_regex(query: str, rows: list[tuple[str, str | None, str | None, str, 
                 "title": title,
                 "trigger": trigger,
                 "task_type": task_type_value,
+                "tags": tags,
                 "match_type": "regex",
                 "score": score,
             }

--- a/penguiflow/skills/models.py
+++ b/penguiflow/skills/models.py
@@ -158,6 +158,21 @@ class SkillQuery(BaseModel):
     search_type: SkillSearchType = "fts"
     top_k: int = Field(default=6, ge=1, le=20)
     task_type: SkillTaskType | None = None
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional AND filter against the skill's declared tags. Empty list "
+            "disables the filter (back-compat default)."
+        ),
+    )
+    namespace: str | None = Field(
+        default=None,
+        description=(
+            "Optional dot-prefix namespace filter. Matches skills whose name "
+            "equals the namespace or starts with '<namespace>.'. None disables "
+            "the filter."
+        ),
+    )
 
 
 class SkillSearchQuery(BaseModel):
@@ -165,6 +180,21 @@ class SkillSearchQuery(BaseModel):
     search_type: SkillSearchType = "fts"
     limit: int = Field(default=8, ge=1, le=20)
     task_type: SkillTaskType | None = None
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional AND filter against the skill's declared tags. Empty list "
+            "disables the filter (back-compat default)."
+        ),
+    )
+    namespace: str | None = Field(
+        default=None,
+        description=(
+            "Optional dot-prefix namespace filter. Matches skills whose name "
+            "equals the namespace or starts with '<namespace>.'. None disables "
+            "the filter."
+        ),
+    )
 
 
 class SkillSearchResult(BaseModel):
@@ -199,6 +229,21 @@ class SkillListRequest(BaseModel):
     page_size: int = Field(default=20, ge=1, le=100)
     task_type: SkillTaskType | None = None
     origin: SkillOrigin | None = None
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional AND filter against the skill's declared tags. Empty list "
+            "disables the filter (back-compat default)."
+        ),
+    )
+    namespace: str | None = Field(
+        default=None,
+        description=(
+            "Optional dot-prefix namespace filter. Matches skills whose name "
+            "equals the namespace or starts with '<namespace>.'. None disables "
+            "the filter."
+        ),
+    )
 
 
 class SkillListEntry(BaseModel):

--- a/penguiflow/skills/provider.py
+++ b/penguiflow/skills/provider.py
@@ -417,6 +417,8 @@ class LocalSkillProvider:
         scope_clause: str,
         scope_params: Sequence[object],
         offset: int = 0,
+        tags: Sequence[str] = (),
+        namespace: str | None = None,
     ) -> tuple[list[SkillRecord], SkillSearchType]:
         results, effective = self._store.search(
             query,
@@ -426,6 +428,8 @@ class LocalSkillProvider:
             task_type=task_type,
             scope_clause=scope_clause,
             scope_params=scope_params,
+            tags=tags,
+            namespace=namespace,
         )
         names = [item["name"] for item in results]
         records = self._store.get_by_name(names, scope_clause=scope_clause, scope_params=scope_params)
@@ -441,6 +445,8 @@ class LocalSkillProvider:
         scope_clause: str,
         scope_params: Sequence[object],
         capability_context: SkillCapabilityContext | None,
+        tags: Sequence[str] = (),
+        namespace: str | None = None,
     ) -> tuple[list[SkillRecord], SkillSearchType]:
         batch_size = max(int(target_count), 1)
         offset = 0
@@ -456,6 +462,8 @@ class LocalSkillProvider:
                 task_type=task_type,
                 scope_clause=scope_clause,
                 scope_params=scope_params,
+                tags=tags,
+                namespace=namespace,
             )
             if not records:
                 break
@@ -486,6 +494,8 @@ class LocalSkillProvider:
             scope_clause=scope_clause,
             scope_params=scope_params,
             capability_context=capability_context,
+            tags=tuple(query.tags),
+            namespace=query.namespace,
         )
         disallowed, tool_search_allowed = _tool_redaction_sets(capability_context)
         detailed = [
@@ -522,6 +532,8 @@ class LocalSkillProvider:
         capability_context: SkillCapabilityContext | None = None,
     ) -> SkillSearchResponse:
         scope_clause, scope_params = _build_scope_filter(tool_context)
+        query_tags = tuple(query.tags)
+        query_namespace = query.namespace
         results, effective = self._store.search(
             query.query,
             search_type=query.search_type,
@@ -529,6 +541,8 @@ class LocalSkillProvider:
             task_type=query.task_type,
             scope_clause=scope_clause,
             scope_params=scope_params,
+            tags=query_tags,
+            namespace=query_namespace,
         )
         effective = cast(SkillSearchType, effective)
         if capability_context is not None:
@@ -540,6 +554,8 @@ class LocalSkillProvider:
                 scope_clause=scope_clause,
                 scope_params=scope_params,
                 capability_context=capability_context,
+                tags=query_tags,
+                namespace=query_namespace,
             )
             applicable_names = {record.name for record in applicable_records}
             if applicable_names:
@@ -550,6 +566,8 @@ class LocalSkillProvider:
                     task_type=query.task_type,
                     scope_clause=scope_clause,
                     scope_params=scope_params,
+                    tags=query_tags,
+                    namespace=query_namespace,
                 )
                 filtered_results = [item for item in results if item["name"] in applicable_names]
                 if len(filtered_results) < len(applicable_names):
@@ -563,6 +581,8 @@ class LocalSkillProvider:
                             task_type=query.task_type,
                             scope_clause=scope_clause,
                             scope_params=scope_params,
+                            tags=query_tags,
+                            namespace=query_namespace,
                         )
                         if not batch:
                             break
@@ -636,6 +656,8 @@ class LocalSkillProvider:
         capability_context: SkillCapabilityContext | None = None,
     ) -> SkillListResponse:
         scope_clause, scope_params = _build_scope_filter(tool_context)
+        req_tags = tuple(req.tags)
+        req_namespace = req.namespace
         if capability_context is None:
             records, total = self._store.list(
                 page=req.page,
@@ -644,6 +666,8 @@ class LocalSkillProvider:
                 origin=req.origin,
                 scope_clause=scope_clause,
                 scope_params=scope_params,
+                tags=req_tags,
+                namespace=req_namespace,
             )
             applicable = records
         else:
@@ -654,6 +678,8 @@ class LocalSkillProvider:
                 origin=req.origin,
                 scope_clause=scope_clause,
                 scope_params=scope_params,
+                tags=req_tags,
+                namespace=req_namespace,
             )
             applicable_records = self._applicable_records(all_records, capability_context)
             total = len(applicable_records)

--- a/penguiflow/skills/tools/skill_list_tool.py
+++ b/penguiflow/skills/tools/skill_list_tool.py
@@ -41,6 +41,8 @@ async def skill_list(args: SkillListArgs, ctx: Any) -> SkillListResponse:
                     "filters": {
                         "task_type": args.task_type,
                         "origin": args.origin,
+                        "tags": list(args.tags),
+                        "namespace": args.namespace,
                     },
                     "returned_count": len(response.skills),
                 },

--- a/penguiflow/skills/tools/skill_search_tool.py
+++ b/penguiflow/skills/tools/skill_search_tool.py
@@ -42,6 +42,8 @@ async def skill_search(args: SkillSearchArgs, ctx: Any) -> SkillSearchResponse:
                     "requested_search_type": args.search_type,
                     "effective_search_type": response.search_type,
                     "results_count": len(response.skills),
+                    "tags": list(args.tags),
+                    "namespace": args.namespace,
                 },
             )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "penguiflow"
-version = "3.8.1"
+version = "3.9.0"
 description = "Async-first orchestration library for multi-agent and data pipelines"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/penguiflow-reactplanner-config/SKILL.md
+++ b/skills/penguiflow-reactplanner-config/SKILL.md
@@ -45,6 +45,16 @@ Always-visible tools (best practice; keep visible and allowed):
 - Common: `finish`
 - Rich output (only if enabled): see [[penguiflow-rich-output]] for the full always-visible set.
 
+Scoping discovery without rewriting the query (optional):
+- `tool_search(args={"query": "send", "tags": ["mail", "write"]})` — AND match against the
+  tool's **declared** tags (auto-expanded name tokens are ignored by this filter).
+- `tool_search(args={"query": "send", "namespace": "microsoft_365"})` — match tools whose
+  name equals the namespace or starts with `<namespace>.`. Dot-prefix only; `_` and `:` are
+  not separators.
+- Filters compose as AND with each other, with the query, and with `task_type` (skills).
+  Empty defaults preserve legacy behavior.
+- `skill_search` accepts the same `tags` / `namespace` args with identical semantics.
+
 ### 4) Enforce allowlists without breaking discovery (ToolPolicy + ToolVisibilityPolicy)
 Use both layers when needed:
 - `ToolPolicy` (planner init): coarse, global allow/deny list and tag requirements.

--- a/skills/penguiflow-runtime-skills-pack/references/retrieval-and-tools.md
+++ b/skills/penguiflow-runtime-skills-pack/references/retrieval-and-tools.md
@@ -8,9 +8,9 @@ When `SkillsConfig.enabled=True`, the planner gets three tools as always-visible
 
 | Tool | Purpose |
 |---|---|
-| `skill_search(query, limit=...)` | Semantic-style search over skills by `trigger` + `tags`. |
+| `skill_search(query, limit=..., tags=[...], namespace=...)` | Semantic-style search over skills by `trigger` + `tags`. Optional `tags` is an AND filter against the skill's declared tags. Optional `namespace` is a dot-prefix match against the skill name (`name == namespace` or `name.startswith(namespace + ".")`). Empty defaults preserve legacy behavior. |
 | `skill_get(names)` | Fetch full text for one or more skills by name. |
-| `skill_list(...)` | Paginated listing for discovery / directory. |
+| `skill_list(..., tags=[...], namespace=...)` | Paginated listing for discovery / directory. Accepts the same `tags` / `namespace` filters as `skill_search`. |
 
 The planner can call these at any step. They go through tool policy / visibility like any other tool, so a `ToolVisibilityPolicy` can hide them per request (e.g., for A2A specialist responses where the LLM shouldn't browse skills).
 

--- a/tests/test_skills_search_filters.py
+++ b/tests/test_skills_search_filters.py
@@ -1,0 +1,339 @@
+"""Tests for skill tag and namespace filters (Phase 2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from penguiflow.skills.local_store import LocalSkillStore
+from penguiflow.skills.models import (
+    SkillDefinition,
+    SkillListRequest,
+    SkillQuery,
+    SkillsConfig,
+    SkillSearchQuery,
+)
+from penguiflow.skills.provider import LocalSkillProvider
+
+
+def _store(tmp_path: Path) -> LocalSkillStore:
+    store = LocalSkillStore(db_path=tmp_path / "skills.db")
+    skills = [
+        SkillDefinition(
+            name="canvas.microsoft365.mail.search_mail",
+            trigger="Search mail",
+            tags=["microsoft365", "mail", "read"],
+            steps=["Step 1"],
+        ),
+        SkillDefinition(
+            name="canvas.microsoft365.mail.send_mail",
+            trigger="Send mail",
+            tags=["microsoft365", "mail", "write"],
+            steps=["Step 1"],
+        ),
+        SkillDefinition(
+            name="canvas.bigquery.list_datasets",
+            trigger="List BigQuery datasets",
+            tags=["bigquery", "read"],
+            steps=["Step 1"],
+        ),
+        SkillDefinition(
+            name="finish",
+            trigger="Finish task",
+            tags=[],
+            steps=["Step 1"],
+            task_type="domain",
+        ),
+    ]
+    for skill in skills:
+        store.upsert_pack_skill(
+            skill,
+            pack_name="testpack",
+            scope_mode="project",
+            update_existing=True,
+        )
+    return store
+
+
+def _search(
+    store: LocalSkillStore,
+    query: str,
+    *,
+    tags: tuple[str, ...] = (),
+    namespace: str | None = None,
+    limit: int = 10,
+    search_type: str = "fts",
+    task_type: str | None = None,
+) -> list[dict]:
+    results, _ = store.search(
+        query,
+        search_type=search_type,  # type: ignore[arg-type]
+        limit=limit,
+        task_type=task_type,  # type: ignore[arg-type]
+        scope_clause="",
+        scope_params=(),
+        tags=tags,
+        namespace=namespace,
+    )
+    return results
+
+
+def test_tags_filter_single(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    results = _search(store, "mail", tags=("microsoft365",))
+    assert {item["name"] for item in results} == {
+        "canvas.microsoft365.mail.search_mail",
+        "canvas.microsoft365.mail.send_mail",
+    }
+
+
+def test_tags_filter_and_match(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    results = _search(store, "mail", tags=("microsoft365", "write"))
+    assert [item["name"] for item in results] == ["canvas.microsoft365.mail.send_mail"]
+
+
+def test_tags_filter_unknown_tag_returns_empty(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    results = _search(store, "mail", tags=("microsoft365", "nonexistent"))
+    assert results == []
+
+
+def test_namespace_filter_dot_prefix(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    results = _search(store, "mail", namespace="canvas.microsoft365")
+    assert {item["name"] for item in results} == {
+        "canvas.microsoft365.mail.search_mail",
+        "canvas.microsoft365.mail.send_mail",
+    }
+
+
+def test_namespace_filter_exact_bare_name(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    results = _search(store, "finish", namespace="finish", search_type="exact")
+    assert [item["name"] for item in results] == ["finish"]
+
+
+def test_namespace_filter_no_underscore_separator(tmp_path: Path) -> None:
+    """Namespace match is dot-prefix only — underscores are not separators."""
+    store = _store(tmp_path)
+    results = _search(store, "list", namespace="canvas_bigquery")
+    assert results == []
+
+
+def test_tags_and_namespace_compose_as_and(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    results = _search(
+        store,
+        "mail",
+        tags=("write",),
+        namespace="canvas.microsoft365",
+    )
+    assert [item["name"] for item in results] == ["canvas.microsoft365.mail.send_mail"]
+
+    # No skill in canvas.bigquery has the 'mail' tag → empty.
+    results = _search(store, "datasets", tags=("mail",), namespace="canvas.bigquery")
+    assert results == []
+
+
+def test_filters_compose_with_task_type(tmp_path: Path) -> None:
+    """task_type AND tags AND namespace all compose."""
+    store = _store(tmp_path)
+    results = _search(store, "finish", task_type="domain", namespace="finish")
+    assert [item["name"] for item in results] == ["finish"]
+
+    # task_type='browser' filters out the lone 'domain'-typed skill.
+    results = _search(store, "finish", task_type="browser", namespace="finish")
+    assert results == []
+
+
+def test_defaults_preserve_back_compat(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    baseline, _ = store.search(
+        "mail",
+        search_type="fts",
+        limit=10,
+        task_type=None,
+        scope_clause="",
+        scope_params=(),
+    )
+    with_defaults, _ = store.search(
+        "mail",
+        search_type="fts",
+        limit=10,
+        task_type=None,
+        scope_clause="",
+        scope_params=(),
+        tags=(),
+        namespace=None,
+    )
+    assert baseline == with_defaults
+
+
+def test_filters_apply_before_paging(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    # With tag filter, only 2 of 4 skills match.
+    results = _search(store, "mail", tags=("microsoft365",), limit=5)
+    assert len(results) == 2
+
+    results = _search(store, "mail", tags=("microsoft365",), limit=1)
+    assert len(results) == 1
+    assert results[0]["name"].startswith("canvas.microsoft365.")
+
+
+@pytest.mark.parametrize("search_type", ["fts", "regex", "exact"])
+def test_filters_apply_across_search_types(search_type: str, tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    query = "canvas.microsoft365.mail.send_mail" if search_type == "exact" else "mail"
+    results = _search(
+        store,
+        query,
+        tags=("microsoft365", "write"),
+        namespace="canvas.microsoft365",
+        search_type=search_type,
+    )
+    assert [item["name"] for item in results] == ["canvas.microsoft365.mail.send_mail"]
+
+
+# -----------------------------------------------------------------------------
+# LocalSkillStore.list() filters
+# -----------------------------------------------------------------------------
+
+
+def test_list_applies_tags_and_namespace(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    records, total = store.list(
+        page=1,
+        page_size=10,
+        task_type=None,
+        origin=None,
+        scope_clause="",
+        scope_params=(),
+        tags=("microsoft365",),
+    )
+    assert total == 2
+    assert {record.name for record in records} == {
+        "canvas.microsoft365.mail.search_mail",
+        "canvas.microsoft365.mail.send_mail",
+    }
+
+    records, total = store.list(
+        page=1,
+        page_size=10,
+        task_type=None,
+        origin=None,
+        scope_clause="",
+        scope_params=(),
+        namespace="canvas.bigquery",
+    )
+    assert total == 1
+    assert records[0].name == "canvas.bigquery.list_datasets"
+
+
+def test_list_defaults_preserve_back_compat(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    baseline = store.list(
+        page=1,
+        page_size=10,
+        task_type=None,
+        origin=None,
+        scope_clause="",
+        scope_params=(),
+    )
+    with_defaults = store.list(
+        page=1,
+        page_size=10,
+        task_type=None,
+        origin=None,
+        scope_clause="",
+        scope_params=(),
+        tags=(),
+        namespace=None,
+    )
+    assert baseline == with_defaults
+
+
+# -----------------------------------------------------------------------------
+# Pydantic model wiring
+# -----------------------------------------------------------------------------
+
+
+def test_skill_search_query_accepts_new_fields() -> None:
+    query = SkillSearchQuery(
+        query="mail",
+        tags=["microsoft365", "write"],
+        namespace="canvas.microsoft365",
+    )
+    assert query.tags == ["microsoft365", "write"]
+    assert query.namespace == "canvas.microsoft365"
+
+    # Defaults preserve back-compat.
+    query = SkillSearchQuery(query="mail")
+    assert query.tags == []
+    assert query.namespace is None
+
+
+def test_skill_query_accepts_new_fields() -> None:
+    query = SkillQuery(task="search", tags=["mail"], namespace="canvas.microsoft365")
+    assert query.tags == ["mail"]
+    assert query.namespace == "canvas.microsoft365"
+
+    query = SkillQuery(task="search")
+    assert query.tags == []
+    assert query.namespace is None
+
+
+def test_skill_list_request_accepts_new_fields() -> None:
+    req = SkillListRequest(tags=["microsoft365"], namespace="canvas.microsoft365")
+    assert req.tags == ["microsoft365"]
+    assert req.namespace == "canvas.microsoft365"
+
+
+# -----------------------------------------------------------------------------
+# LocalSkillProvider end-to-end
+# -----------------------------------------------------------------------------
+
+
+def _provider(tmp_path: Path) -> LocalSkillProvider:
+    config = SkillsConfig(enabled=True, cache_dir=str(tmp_path))
+    store = _store(tmp_path)
+    return LocalSkillProvider(config, store=store)
+
+
+@pytest.mark.asyncio
+async def test_provider_search_forwards_filters(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    response = await provider.search(
+        SkillSearchQuery(query="mail", tags=["write"], namespace="canvas.microsoft365"),
+        tool_context={},
+    )
+    assert [skill.name for skill in response.skills] == [
+        "canvas.microsoft365.mail.send_mail"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provider_get_relevant_forwards_filters(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    response = await provider.get_relevant(
+        SkillQuery(task="mail", tags=["write"], namespace="canvas.microsoft365"),
+        tool_context={},
+    )
+    assert [skill.name for skill in response.skills] == [
+        "canvas.microsoft365.mail.send_mail"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provider_list_forwards_filters(tmp_path: Path) -> None:
+    provider = _provider(tmp_path)
+    response = await provider.list(
+        SkillListRequest(tags=["microsoft365"]),
+        tool_context={},
+    )
+    assert {entry.name for entry in response.skills} == {
+        "canvas.microsoft365.mail.search_mail",
+        "canvas.microsoft365.mail.send_mail",
+    }
+    assert response.total == 2

--- a/tests/test_tool_search_filters.py
+++ b/tests/test_tool_search_filters.py
@@ -1,0 +1,335 @@
+"""Tests for ToolSearchCache tag and namespace filters (Phase 1).
+
+These exercises cover the back-compatible filter args added to
+``ToolSearchCache.search`` and ``ToolSearchArgs``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from penguiflow.catalog import ToolLoadingMode, build_catalog, tool
+from penguiflow.node import Node
+from penguiflow.planner.tool_search_cache import ToolSearchCache
+from penguiflow.planner.tool_search_tool import ToolSearchArgs
+from penguiflow.registry import ModelRegistry
+
+
+class _Args(BaseModel):
+    text: str
+
+
+class _Out(BaseModel):
+    text: str
+
+
+@tool(desc="Send a mail message via Microsoft 365.", tags=["mail", "write"])
+async def microsoft_send_mail(args: _Args, ctx: Any) -> _Out:
+    del ctx
+    return _Out(text=args.text)
+
+
+@tool(desc="Search Microsoft 365 mail.", tags=["mail", "read"])
+async def microsoft_search_mail(args: _Args, ctx: Any) -> _Out:
+    del ctx
+    return _Out(text=args.text)
+
+
+@tool(desc="List BigQuery datasets.", tags=["bigquery", "read"])
+async def explorer_list_datasets(args: _Args, ctx: Any) -> _Out:
+    del ctx
+    return _Out(text=args.text)
+
+
+@tool(desc="Terminate the task.", tags=[], loading_mode=ToolLoadingMode.ALWAYS)
+async def finish_tool(args: _Args, ctx: Any) -> _Out:
+    del ctx
+    return _Out(text=args.text)
+
+
+def _build_cache(tmp_path: Path) -> ToolSearchCache:
+    registry = ModelRegistry()
+    registry.register("microsoft_365.send_mail", _Args, _Out)
+    registry.register("microsoft_365.search_mail", _Args, _Out)
+    registry.register("explorer.list_datasets", _Args, _Out)
+    registry.register("finish", _Args, _Out)
+    nodes = [
+        Node(microsoft_send_mail, name="microsoft_365.send_mail"),
+        Node(microsoft_search_mail, name="microsoft_365.search_mail"),
+        Node(explorer_list_datasets, name="explorer.list_datasets"),
+        Node(finish_tool, name="finish"),
+    ]
+    specs = build_catalog(nodes, registry)
+    cache = ToolSearchCache(cache_dir=str(tmp_path))
+    cache.sync_tools(specs)
+    return cache
+
+
+def _search(
+    cache: ToolSearchCache,
+    query: str,
+    *,
+    tags: tuple[str, ...] = (),
+    namespace: str | None = None,
+    limit: int = 10,
+    search_type: str = "fts",
+) -> list[dict[str, Any]]:
+    results, _ = cache.search(
+        query,
+        search_type=search_type,
+        limit=limit,
+        include_always_loaded=True,
+        allowed_names=None,
+        tags=tags,
+        namespace=namespace,
+    )
+    return results
+
+
+def test_tags_filter_single(tmp_path: Path) -> None:
+    cache = _build_cache(tmp_path)
+    results = _search(cache, "mail", tags=("mail",))
+    assert {item["name"] for item in results} == {
+        "microsoft_365.send_mail",
+        "microsoft_365.search_mail",
+    }
+
+
+def test_tags_filter_and_match(tmp_path: Path) -> None:
+    cache = _build_cache(tmp_path)
+    results = _search(cache, "mail", tags=("mail", "write"))
+    assert [item["name"] for item in results] == ["microsoft_365.send_mail"]
+
+
+def test_tags_filter_unknown_tag_returns_empty(tmp_path: Path) -> None:
+    cache = _build_cache(tmp_path)
+    results = _search(cache, "mail", tags=("mail", "doesnotexist"))
+    assert results == []
+
+
+def test_tags_filter_ignores_auto_expanded_name_tokens(tmp_path: Path) -> None:
+    """The declared-tags filter must not match name-token expansions."""
+    cache = _build_cache(tmp_path)
+    # "send" is a token in microsoft_365.send_mail and gets added to the
+    # auto-expanded ``tags`` column for FTS recall. The explicit ``tags``
+    # filter must consult only declared tags, so passing tags=("send",)
+    # should return nothing — none of the tools declare ``send`` as a tag.
+    results = _search(cache, "mail", tags=("send",))
+    assert results == []
+
+
+def test_namespace_filter_dot_prefix(tmp_path: Path) -> None:
+    cache = _build_cache(tmp_path)
+    results = _search(cache, "mail", namespace="microsoft_365")
+    assert {item["name"] for item in results} == {
+        "microsoft_365.send_mail",
+        "microsoft_365.search_mail",
+    }
+
+
+def test_namespace_filter_does_not_match_underscore_prefix(tmp_path: Path) -> None:
+    """Namespace is dot-prefix only; underscore is NOT a separator."""
+    cache = _build_cache(tmp_path)
+    results = _search(cache, "datasets", namespace="explorer")
+    assert {item["name"] for item in results} == {"explorer.list_datasets"}
+
+    # 'explorer_list' should not match 'explorer.list_datasets'.
+    results = _search(cache, "datasets", namespace="explorer_list")
+    assert results == []
+
+
+def test_namespace_filter_exact_bare_name(tmp_path: Path) -> None:
+    cache = _build_cache(tmp_path)
+    # Bare-name tool: namespace="finish" matches via the name==namespace branch.
+    results = _search(cache, "finish", namespace="finish", search_type="exact")
+    assert [item["name"] for item in results] == ["finish"]
+
+
+def test_filters_default_is_back_compat(tmp_path: Path) -> None:
+    cache = _build_cache(tmp_path)
+    baseline, _ = cache.search(
+        "mail",
+        search_type="fts",
+        limit=10,
+        include_always_loaded=True,
+        allowed_names=None,
+    )
+    with_defaults, _ = cache.search(
+        "mail",
+        search_type="fts",
+        limit=10,
+        include_always_loaded=True,
+        allowed_names=None,
+        tags=(),
+        namespace=None,
+    )
+    assert baseline == with_defaults
+
+
+def test_filters_compose_as_and(tmp_path: Path) -> None:
+    cache = _build_cache(tmp_path)
+    results = _search(
+        cache,
+        "mail",
+        tags=("mail",),
+        namespace="microsoft_365",
+    )
+    assert {item["name"] for item in results} == {
+        "microsoft_365.send_mail",
+        "microsoft_365.search_mail",
+    }
+
+    # Compose AND with a tag the namespace doesn't contain → empty.
+    results = _search(
+        cache,
+        "mail",
+        tags=("bigquery",),
+        namespace="microsoft_365",
+    )
+    assert results == []
+
+
+def test_filters_apply_before_paging(tmp_path: Path) -> None:
+    """Limit must yield up to N *post-filter* results, not N raw matches."""
+    cache = _build_cache(tmp_path)
+    # 4 tools total; restricting to mail tag leaves 2 of them.
+    results = _search(cache, "mail", tags=("mail",), limit=5)
+    assert len(results) == 2
+
+    # With limit=1 we still get exactly 1 matching tool (not pruned to 0).
+    results = _search(cache, "mail", tags=("mail",), limit=1)
+    assert len(results) == 1
+    assert results[0]["name"] in {"microsoft_365.send_mail", "microsoft_365.search_mail"}
+
+
+def test_tool_search_args_accepts_new_fields() -> None:
+    args = ToolSearchArgs(query="mail", tags=["mail", "write"], namespace="microsoft_365")
+    assert args.tags == ["mail", "write"]
+    assert args.namespace == "microsoft_365"
+    # Defaults remain back-compat.
+    args = ToolSearchArgs(query="mail")
+    assert args.tags == []
+    assert args.namespace is None
+
+
+def test_schema_migrates_from_v1_to_v2(tmp_path: Path) -> None:
+    """A cache file written under schema v1 must be readable after upgrade.
+
+    Sets up a faithful v1 cache (tools table + FTS index + triggers, no
+    declared_tags column, schema_version=1) with a row that survives into v2.
+    The migration path must add the column, re-populate declared_tags for the
+    surviving row, and keep the new tag filter working.
+    """
+
+    import sqlite3
+
+    db_path = tmp_path / "tool_cache.db"
+    # Simulate a legacy v1 cache: tools table without ``declared_tags`` but
+    # otherwise faithful — including the FTS index and triggers that v1 wrote.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE tools (
+                name TEXT PRIMARY KEY,
+                description TEXT NOT NULL,
+                tags TEXT NOT NULL,
+                side_effects TEXT NOT NULL,
+                loading_mode TEXT NOT NULL,
+                record_hash TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE tool_index_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE VIRTUAL TABLE tools_fts USING fts5(
+                name,
+                description,
+                tags,
+                content='tools',
+                content_rowid='rowid',
+                tokenize='porter unicode61'
+            )
+            """
+        )
+        conn.executescript(
+            """
+            CREATE TRIGGER tools_ai AFTER INSERT ON tools BEGIN
+                INSERT INTO tools_fts(rowid, name, description, tags)
+                VALUES (new.rowid, new.name, new.description, new.tags);
+            END;
+            CREATE TRIGGER tools_ad AFTER DELETE ON tools BEGIN
+                INSERT INTO tools_fts(tools_fts, rowid, name, description, tags)
+                VALUES('delete', old.rowid, old.name, old.description, old.tags);
+            END;
+            CREATE TRIGGER tools_au AFTER UPDATE ON tools BEGIN
+                INSERT INTO tools_fts(tools_fts, rowid, name, description, tags)
+                VALUES('delete', old.rowid, old.name, old.description, old.tags);
+                INSERT INTO tools_fts(rowid, name, description, tags)
+                VALUES (new.rowid, new.name, new.description, new.tags);
+            END;
+            """
+        )
+        # Surviving row (same name as the new sync below).
+        conn.execute(
+            "INSERT INTO tools (name, description, tags, side_effects, loading_mode, record_hash) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "microsoft_365.send_mail",
+                "Legacy desc",
+                '["legacy_tag"]',
+                "pure",
+                "always",
+                "legacy_hash",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO tool_index_meta (key, value) VALUES (?, ?)",
+            ("schema_version", "1"),
+        )
+
+    cache = ToolSearchCache(cache_dir=str(tmp_path))
+    # First sync after schema bump should detect outdated version and force
+    # re-upsert so declared_tags is populated for the surviving row.
+    registry = ModelRegistry()
+    registry.register("microsoft_365.send_mail", _Args, _Out)
+    specs = build_catalog(
+        [Node(microsoft_send_mail, name="microsoft_365.send_mail")],
+        registry,
+    )
+    cache.sync_tools(specs)
+
+    results, _ = cache.search(
+        "mail",
+        search_type="fts",
+        limit=5,
+        include_always_loaded=True,
+        allowed_names=None,
+        tags=("mail",),
+    )
+    assert {item["name"] for item in results} == {"microsoft_365.send_mail"}
+
+
+@pytest.mark.parametrize("search_type", ["fts", "regex", "exact"])
+def test_filters_apply_across_search_types(search_type: str, tmp_path: Path) -> None:
+    cache = _build_cache(tmp_path)
+    query = "microsoft_365.send_mail" if search_type == "exact" else "mail"
+    results = _search(
+        cache,
+        query,
+        tags=("mail", "write"),
+        namespace="microsoft_365",
+        search_type=search_type,
+    )
+    assert [item["name"] for item in results] == ["microsoft_365.send_mail"]

--- a/uv.lock
+++ b/uv.lock
@@ -3045,7 +3045,7 @@ wheels = [
 
 [[package]]
 name = "penguiflow"
-version = "3.8.1"
+version = "3.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Exposes the existing FTS5-indexed `tags` columns as typed filter args on `ToolSearchArgs`, `SkillSearchQuery`, `SkillQuery`, and `SkillListRequest`, plus the corresponding `ToolSearchCache.search` / `LocalSkillStore.search` / `LocalSkillStore.list` kwargs. Tags are AND-matched against declared-only tag lists (a new `declared_tags` column on the tools cache prevents the FTS-recall name-token expansion from polluting filter results); namespaces use dot-prefix match (`name == ns` or `name.startswith(ns + ".")`), consistent with existing `match_namespaces` semantics. All filters compose as AND with each other, with `task_type`, and with the query itself; empty defaults preserve legacy behavior byte-for-byte.

Tool cache schema bumps to v2 with an idempotent `ALTER TABLE` migration and a forced re-upsert (no destructive DELETE) so pre-existing caches populate the new column without disturbing the FTS index. Skill store needed no schema change.

Adds 36 tests covering AND-composition, dot-prefix-only namespace match (no `_`/`:` separators), filter-before-paging, back-compat defaults across fts/regex/exact, and the v1->v2 migration path with a faithful pre-v2 FTS fixture. Coverage 85.71% (gate 84.5%). Version bumped 3.8.1 -> 3.9.0.